### PR TITLE
chore: fix docstring formatting and update copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -185,7 +185,7 @@
       comment syntax for the file format. Please also get an approval
       from your organization before applying the license.
 
-   Copyright 2026 XCENA
+   Copyright 2026 XCENA Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/maru/__init__.py
+++ b/maru/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Maru - Shared memory KV cache for LLM inference.
 
 Maru (마루, /mɑːruː/) — named after the central open floor

--- a/maru_common/__init__.py
+++ b/maru_common/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Maru Common - Shared types and utilities for Maru shared memory KV cache system."""
 
 from .logging_setup import setup_package_logging  # noqa: E402

--- a/maru_common/config.py
+++ b/maru_common/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 import os
 from dataclasses import dataclass
 

--- a/maru_common/logging_setup.py
+++ b/maru_common/logging_setup.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Shared logging setup for Maru packages."""
 
 import logging

--- a/maru_common/protocol.py
+++ b/maru_common/protocol.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Maru Protocol - Message definitions for RPC communication.
 
 This module defines the protocol for communication between Maru
 clients and the MaruServer using binary format (MessagePack).
 
-Binary Format:
+Binary Format::
+
     [Header (16 bytes)] [Payload (MessagePack encoded)]
 
 See docs/protocol.md for full specification.
@@ -92,7 +93,8 @@ class MessageHeader:
     """
     Protocol message header (16 bytes).
 
-    Format (network byte order):
+    Format (network byte order)::
+
         magic: 2 bytes - 0xCF00
         version: 1 byte - Protocol version (currently 1)
         msg_type: 1 byte - MessageType code

--- a/maru_common/resource_manager_installer.py
+++ b/maru_common/resource_manager_installer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Console script entry point for installing the Maru Resource Manager.
 
 Wraps the cmake build + install workflow so that after `pip install -e .`,

--- a/maru_common/serializer.py
+++ b/maru_common/serializer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Message serialization for RPC protocol.
 
 Binary-only serialization using MessagePack with protocol header.
@@ -48,7 +48,8 @@ class Serializer:
     """
     Binary message serializer using MessagePack.
 
-    Message format:
+    Message format::
+
         [Header 16 bytes][MessagePack payload]
     """
 

--- a/maru_handler/__init__.py
+++ b/maru_handler/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Maru Handler package.
 
 This package provides the main client interface for Maru shared memory KV cache.

--- a/maru_handler/handler.py
+++ b/maru_handler/handler.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """MaruHandler - Main interface for Maru shared memory KV cache client.
 
 This module provides the primary entry point for clients to interact with
@@ -76,7 +76,8 @@ class MaruHandler:
     - ``close()`` sets ``_closing`` event to reject new operations, then
       acquires ``_write_lock`` to wait for in-flight writes before teardown.
 
-    Architecture:
+    Architecture::
+
         MaruHandler
             ├── RpcClient (server communication, sole RPC owner)
             ├── DaxMapper (memory mapping via MaruShmClient, owns all mmap/munmap)

--- a/maru_handler/memory/__init__.py
+++ b/maru_handler/memory/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Memory management components for Maru Handler.
 
 Provides:

--- a/maru_handler/memory/allocator.py
+++ b/maru_handler/memory/allocator.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Paged memory allocator for shared memory regions.
 
 Fixed-size page allocator over a pre-mapped memory region.

--- a/maru_handler/memory/mapper.py
+++ b/maru_handler/memory/mapper.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """DaxMapper - Memory mapping via MaruShmClient.
 
 Single owner of MaruShmClient for mmap/munmap operations.

--- a/maru_handler/memory/owned_region_manager.py
+++ b/maru_handler/memory/owned_region_manager.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """OwnedRegionManager - Manages multiple owned regions with PagedMemoryAllocator.
 
 Handles allocation, write, and region lifecycle via DaxMapper.
@@ -28,7 +28,8 @@ class OwnedRegionManager:
     allocate() returns None and the caller (Handler) is responsible
     for requesting a new region via RPC and calling add_region().
 
-    Architecture:
+    Architecture::
+
         OwnedRegionManager
             ├── DaxMapper (shared, for mmap/munmap)
             └── OwnedRegion[]

--- a/maru_handler/memory/types.py
+++ b/maru_handler/memory/types.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Type definitions for memory management components."""
 
 import logging

--- a/maru_handler/rpc_async_client.py
+++ b/maru_handler/rpc_async_client.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Async RPC Client for connecting to MaruServer (v1 — asyncio).
 
 Uses a background asyncio event loop with zmq.asyncio DEALER socket.
 Supports both blocking (_send_request) and non-blocking (_send_request_nonblocking)
 call patterns, enabling pipelining for concurrent in-flight requests.
 
-Architecture:
+Architecture::
+
     Caller Thread (MaruHandler)
         |
         v

--- a/maru_handler/rpc_client.py
+++ b/maru_handler/rpc_client.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """RPC Client for connecting to MaruServer."""
 
 import logging

--- a/maru_server/__init__.py
+++ b/maru_server/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """MaruServer - Central metadata server for Maru shared memory KV cache."""
 
 from maru_common.logging_setup import setup_package_logging  # noqa: E402

--- a/maru_server/__main__.py
+++ b/maru_server/__main__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Entry point for python -m maru_server."""
 
 from maru_server.server import main

--- a/maru_server/allocation_manager.py
+++ b/maru_server/allocation_manager.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Allocation Manager - Server-side memory allocation lifecycle management."""
 
 import logging

--- a/maru_server/kv_manager.py
+++ b/maru_server/kv_manager.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """KV Manager implementation for managing KV metadata."""
 
 import logging

--- a/maru_server/rpc_async_server.py
+++ b/maru_server/rpc_async_server.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """RpcAsyncServer - Async ZeroMQ RPC server using ROUTER/DEALER proxy with worker pool.
 
 Uses zmq.proxy to distribute incoming requests across N worker threads,
 enabling concurrent request handling while maintaining the same interface
 as the synchronous RpcServer.
 
-Architecture:
+Architecture::
+
     ROUTER socket (tcp://host:port, frontend)
         |
         zmq.proxy() — runs in proxy_thread (blocking)

--- a/maru_server/rpc_server.py
+++ b/maru_server/rpc_server.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """RpcServer - ZeroMQ-based RPC server for MaruServer."""
 
 import logging

--- a/maru_server/server.py
+++ b/maru_server/server.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """MaruServer - Main server implementation."""
 
 import argparse

--- a/maru_shm/__init__.py
+++ b/maru_shm/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """maru_shm — Shared memory client library and shared types for Maru.
 
 This package provides the types, IPC protocol, and client for communicating

--- a/maru_shm/client.py
+++ b/maru_shm/client.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """MaruShmClient — shared memory client for the Maru Resource Manager.
 
 Communicates with the resource manager over UDS using the binary IPC protocol

--- a/maru_shm/constants.py
+++ b/maru_shm/constants.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Constants for maru_shm.
 
 Defines protection flags, mapping flags, default paths, and alignment constants.

--- a/maru_shm/ipc.py
+++ b/maru_shm/ipc.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Binary IPC protocol for resource manager <-> client communication.
 
 This protocol is used over UDS (Unix Domain Sockets) between the Maru Resource Manager
 and MaruShmClient. It is separate from the maru RPC protocol in
 maru_common/protocol.py which uses MessagePack over ZMQ.
 
-Wire format:
+Wire format::
+
     [MsgHeader (12 bytes)] [payload (variable)]
 """
 
@@ -47,7 +48,8 @@ HEADER_SIZE = struct.calcsize(_HEADER_FORMAT)  # 12
 class MsgHeader:
     """IPC message header (12 bytes).
 
-    Wire layout (native byte order):
+    Wire layout (native byte order)::
+
         magic:       4 bytes (0x4D415255)
         version:     2 bytes
         msg_type:    2 bytes (MsgType)

--- a/maru_shm/types.py
+++ b/maru_shm/types.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Shared memory types for maru_shm.
 
 Defines MaruHandle, MaruPoolInfo, and DaxType — the core data structures

--- a/maru_shm/uds_helpers.py
+++ b/maru_shm/uds_helpers.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """UDS (Unix Domain Socket) helper utilities.
 
 Provides SCM_RIGHTS FD passing, SO_PEERCRED peer credentials,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """pytest configuration and fixtures."""
 
 import sys

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Integration tests for MaruHandler client interface."""
 
 import pytest

--- a/tests/integration/test_rpc_async.py
+++ b/tests/integration/test_rpc_async.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Integration tests for RpcAsyncServer + RpcAsyncClient.
 
 Tests cover all message types end-to-end through the async RPC layer:

--- a/tests/integration/test_rpc_sync.py
+++ b/tests/integration/test_rpc_sync.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Integration tests for sync RPC client-server communication.
 
 Tests cover:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit test configuration — MockShmClient for tests without a running resource manager."""
 
 import mmap

--- a/tests/unit/test_allocation_manager.py
+++ b/tests/unit/test_allocation_manager.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Tests for AllocationManager."""
 
 from maru_server.allocation_manager import AllocationManager

--- a/tests/unit/test_allocator.py
+++ b/tests/unit/test_allocator.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Tests for PagedMemoryAllocator."""
 
 import pytest

--- a/tests/unit/test_batch_operations.py
+++ b/tests/unit/test_batch_operations.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Tests for batch operations - server-side unit tests."""
 
 from maru_server.kv_manager import KVManager

--- a/tests/unit/test_kv_manager.py
+++ b/tests/unit/test_kv_manager.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Tests for KV Manager."""
 
 from maru_server.kv_manager import KVManager

--- a/tests/unit/test_logging_setup.py
+++ b/tests/unit/test_logging_setup.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit tests for logging_setup module."""
 
 import logging

--- a/tests/unit/test_mapper.py
+++ b/tests/unit/test_mapper.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Tests for DaxMapper."""
 
 import ctypes

--- a/tests/unit/test_maru_handler.py
+++ b/tests/unit/test_maru_handler.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit tests for MaruHandler client interface.
 
 Uses mocked RPC — no real ZMQ server needed.

--- a/tests/unit/test_maru_server.py
+++ b/tests/unit/test_maru_server.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit tests for MaruServer orchestration logic."""
 
 from maru_server.server import MaruServer

--- a/tests/unit/test_maru_shm.py
+++ b/tests/unit/test_maru_shm.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit tests for maru_shm package (Phase 1).
 
 Tests cover:

--- a/tests/unit/test_memory_types.py
+++ b/tests/unit/test_memory_types.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit tests for memory types (MappedRegion, MemoryInfo)."""
 
 import mmap

--- a/tests/unit/test_owned_region_manager.py
+++ b/tests/unit/test_owned_region_manager.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Tests for OwnedRegionManager.
 
 Pure unit tests — no RPC server needed.

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit tests for protocol module."""
 
 import pytest

--- a/tests/unit/test_rpc_async_client.py
+++ b/tests/unit/test_rpc_async_client.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit tests for RpcAsyncClient to achieve 100% coverage."""
 
 import asyncio

--- a/tests/unit/test_rpc_client.py
+++ b/tests/unit/test_rpc_client.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit tests for RpcClient to achieve 100% coverage."""
 
 from unittest.mock import MagicMock, patch

--- a/tests/unit/test_rpc_server.py
+++ b/tests/unit/test_rpc_server.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit tests for RpcServer and RpcAsyncServer handler dispatch logic."""
 
 import logging

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit tests for serializer module."""
 
 import pytest

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit tests for server.py CLI utilities (setup_logging, main)."""
 
 import logging

--- a/tests/unit/test_shm_client.py
+++ b/tests/unit/test_shm_client.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Unit tests for ShmClient (Phase 3).
 
 Tests use a mock UDS server via socketpair to verify client behavior

--- a/tests/unit/test_thread_safety.py
+++ b/tests/unit/test_thread_safety.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 XCENA
+# Copyright 2026 XCENA Inc.
 """Thread-safety tests for MaruHandler, OwnedRegionManager, and DaxMapper.
 
 Unit tests — no RPC server needed.


### PR DESCRIPTION
## Summary

Fix docstring formatting for Sphinx autodoc rendering and update copyright holder across all source files.

## Key Changes

- **Docstring formatting**: Apply rST literal block syntax (`::`) for ASCII art diagrams and structured format descriptions so they render correctly in Sphinx (7 files)
- **Copyright update**: `Copyright 2026 XCENA` → `Copyright 2026 XCENA Inc.` across all 53 source/test files and LICENSE

## Test Plan

- [x] Existing tests pass (`pytest -v`)
- [x] Pre-commit hooks pass (ruff, ruff-format)