### PR TITLE
feat: add pool_id config for dax device pinning

### DIFF
--- a/maru_common/config.py
+++ b/maru_common/config.py
@@ -50,6 +50,7 @@ class MaruConfig:
     use_async_rpc: bool = True  # Use async DEALER-ROUTER RPC (RpcAsyncClient)
     max_inflight: int = 64  # Max concurrent in-flight async requests (backpressure)
     eager_map: bool = True  # Pre-map all shared regions on connect
+    pool_id: int | None = None  # None means any pool (ANY_POOL_ID = 0xFFFFFFFF)
 
     def __post_init__(self):
         """Generate instance_id if not provided. Validate config."""

--- a/maru_common/protocol.py
+++ b/maru_common/protocol.py
@@ -158,6 +158,7 @@ class RequestAllocRequest:
 
     instance_id: str
     size: int
+    pool_id: int = 0xFFFFFFFF  # ANY_POOL_ID
 
 
 @dataclass

--- a/maru_handler/handler.py
+++ b/maru_handler/handler.py
@@ -95,6 +95,7 @@ class MaruHandler:
             config: Configuration object. If None, uses defaults.
         """
         self._config = config or MaruConfig()
+        self._pool_id = self._config.pool_id if self._config.pool_id is not None else 0xFFFFFFFF
         if self._config.use_async_rpc:
             from .rpc_async_client import RpcAsyncClient
 
@@ -150,6 +151,7 @@ class MaruHandler:
             response = self._rpc.request_alloc(
                 instance_id=self._config.instance_id,
                 size=self._config.pool_size,
+                pool_id=self._pool_id,
             )
             if not response.success or response.handle is None:
                 logger.error(
@@ -981,6 +983,7 @@ class MaruHandler:
             response = self._rpc.request_alloc(
                 instance_id=self._config.instance_id,
                 size=self._config.pool_size,
+                pool_id=self._pool_id,
             )
         except Exception:
             logger.error("RPC request_alloc failed during expand", exc_info=True)

--- a/maru_handler/rpc_async_client.py
+++ b/maru_handler/rpc_async_client.py
@@ -359,11 +359,13 @@ class RpcAsyncClient:
     # Allocation Management (blocking)
     # =========================================================================
 
-    def request_alloc(self, instance_id: str, size: int) -> RequestAllocResponse:
+    def request_alloc(
+        self, instance_id: str, size: int, pool_id: int = 0xFFFFFFFF
+    ) -> RequestAllocResponse:
         """Request a new memory allocation."""
         response = self._send_request(
             MessageType.REQUEST_ALLOC,
-            {"instance_id": instance_id, "size": size},
+            {"instance_id": instance_id, "size": size, "pool_id": pool_id},
         )
         return self._parse_request_alloc(response)
 
@@ -484,13 +486,15 @@ class RpcAsyncClient:
     # Non-blocking Async API (*_async methods)
     # =========================================================================
 
-    def request_alloc_async(self, instance_id: str, size: int) -> Future:
+    def request_alloc_async(
+        self, instance_id: str, size: int, pool_id: int = 0xFFFFFFFF
+    ) -> Future:
         """Non-blocking request_alloc. Returns Future[RequestAllocResponse]."""
 
         async def _coro():
             response = await self._send_async(
                 MessageType.REQUEST_ALLOC,
-                {"instance_id": instance_id, "size": size},
+                {"instance_id": instance_id, "size": size, "pool_id": pool_id},
             )
             return self._parse_request_alloc(response)
 

--- a/maru_handler/rpc_client.py
+++ b/maru_handler/rpc_client.py
@@ -125,13 +125,16 @@ class RpcClient:
     # Allocation Management
     # =========================================================================
 
-    def request_alloc(self, instance_id: str, size: int) -> RequestAllocResponse:
+    def request_alloc(
+        self, instance_id: str, size: int, pool_id: int = 0xFFFFFFFF
+    ) -> RequestAllocResponse:
         """
         Request a new memory allocation.
 
         Args:
             instance_id: Client instance identifier
             size: Requested size in bytes
+            pool_id: Pool to allocate from (0xFFFFFFFF means any pool)
 
         Returns:
             RequestAllocResponse with handle on success
@@ -141,6 +144,7 @@ class RpcClient:
             {
                 "instance_id": instance_id,
                 "size": size,
+                "pool_id": pool_id,
             },
         )
 

--- a/maru_server/allocation_manager.py
+++ b/maru_server/allocation_manager.py
@@ -29,9 +29,11 @@ class AllocationManager:
         self._allocations: dict[int, AllocationInfo] = {}  # region_id -> info
         self._lock = RLock()
 
-    def allocate(self, instance_id: str, size: int) -> MaruHandle | None:
+    def allocate(
+        self, instance_id: str, size: int, pool_id: int = 0xFFFFFFFF
+    ) -> MaruHandle | None:
         """Allocate memory via ShmClient and track ownership."""
-        handle = self._client.alloc(size)
+        handle = self._client.alloc(size, pool_id=pool_id)
         if handle is None:
             return None
 

--- a/maru_server/rpc_async_server.py
+++ b/maru_server/rpc_async_server.py
@@ -270,6 +270,7 @@ class RpcAsyncServer:
         handle = self._server.request_alloc(
             instance_id=req.instance_id,
             size=req.size,
+            pool_id=req.pool_id,
         )
         if handle is None:
             logger.debug(

--- a/maru_server/rpc_handler_mixin.py
+++ b/maru_server/rpc_handler_mixin.py
@@ -59,6 +59,7 @@ class RpcHandlerMixin:
         handle = self._server.request_alloc(
             instance_id=req.instance_id,
             size=req.size,
+            pool_id=req.pool_id,
         )
         if handle is None:
             logger.debug(

--- a/maru_server/rpc_server.py
+++ b/maru_server/rpc_server.py
@@ -138,6 +138,7 @@ class RpcServer:
         handle = self._server.request_alloc(
             instance_id=req.instance_id,
             size=req.size,
+            pool_id=req.pool_id,
         )
         if handle is None:
             logger.debug(

--- a/maru_server/server.py
+++ b/maru_server/server.py
@@ -34,9 +34,11 @@ class MaruServer:
     # Allocation Management
     # =========================================================================
 
-    def request_alloc(self, instance_id: str, size: int) -> MaruHandle | None:
+    def request_alloc(
+        self, instance_id: str, size: int, pool_id: int = 0xFFFFFFFF
+    ) -> MaruHandle | None:
         """Handle allocation request from client."""
-        handle = self._allocation_manager.allocate(instance_id, size)
+        handle = self._allocation_manager.allocate(instance_id, size, pool_id=pool_id)
         if handle:
             logger.info(
                 "Allocated %d bytes for %s: region_id=%d",

--- a/tests/unit/test_maru_server.py
+++ b/tests/unit/test_maru_server.py
@@ -290,7 +290,7 @@ class TestMaruServerEdgeCases:
 
         # Mock the allocation manager to return None
         original_alloc = server._allocation_manager.allocate
-        server._allocation_manager.allocate = lambda instance_id, size: None  # type: ignore
+        server._allocation_manager.allocate = lambda instance_id, size, pool_id=0xFFFFFFFF: None  # type: ignore
 
         result = server.request_alloc("instance1", 4096)
         assert result is None

--- a/tests/unit/test_rpc_async_client.py
+++ b/tests/unit/test_rpc_async_client.py
@@ -339,7 +339,7 @@ class TestRpcAsyncClientApiMethods:
         result = client.request_alloc("instance-1", 4096)
 
         client._send_request.assert_called_once_with(
-            MessageType.REQUEST_ALLOC, {"instance_id": "instance-1", "size": 4096}
+            MessageType.REQUEST_ALLOC, {"instance_id": "instance-1", "size": 4096, "pool_id": 0xFFFFFFFF}
         )
         assert result.success is True
         assert result.handle is not None

--- a/tests/unit/test_rpc_client.py
+++ b/tests/unit/test_rpc_client.py
@@ -278,7 +278,7 @@ class TestRpcClientApiMethods:
         result = client.request_alloc(instance_id="test_instance", size=4096)
 
         mock_send.assert_called_once_with(
-            MessageType.REQUEST_ALLOC, {"instance_id": "test_instance", "size": 4096}
+            MessageType.REQUEST_ALLOC, {"instance_id": "test_instance", "size": 4096, "pool_id": 0xFFFFFFFF}
         )
         assert isinstance(result, RequestAllocResponse)
         assert result.success is True
@@ -295,7 +295,7 @@ class TestRpcClientApiMethods:
         result = client.request_alloc(instance_id="test_instance", size=999999)
 
         mock_send.assert_called_once_with(
-            MessageType.REQUEST_ALLOC, {"instance_id": "test_instance", "size": 999999}
+            MessageType.REQUEST_ALLOC, {"instance_id": "test_instance", "size": 999999, "pool_id": 0xFFFFFFFF}
         )
         assert isinstance(result, RequestAllocResponse)
         assert result.success is False

--- a/tests/unit/test_rpc_handler_mixin.py
+++ b/tests/unit/test_rpc_handler_mixin.py
@@ -52,7 +52,7 @@ class TestRpcHandlerMixin:
 
     def test_handle_request_alloc_success(self):
         handler, server = self._make_handler()
-        req = MockRequest(instance_id="inst1", size=4096)
+        req = MockRequest(instance_id="inst1", size=4096, pool_id=0xFFFFFFFF)
         resp = handler._handle_request_alloc(req)
         assert resp["success"] is True
         assert "handle" in resp
@@ -60,9 +60,9 @@ class TestRpcHandlerMixin:
     def test_handle_request_alloc_failure(self, monkeypatch):
         handler, server = self._make_handler()
         monkeypatch.setattr(
-            server._allocation_manager, "allocate", lambda instance_id, size: None
+            server._allocation_manager, "allocate", lambda instance_id, size, pool_id=0xFFFFFFFF: None
         )
-        req = MockRequest(instance_id="inst1", size=4096)
+        req = MockRequest(instance_id="inst1", size=4096, pool_id=0xFFFFFFFF)
         resp = handler._handle_request_alloc(req)
         assert resp["success"] is False
         assert resp["error"] == "Allocation failed"

--- a/tests/unit/test_rpc_server.py
+++ b/tests/unit/test_rpc_server.py
@@ -51,10 +51,10 @@ class TestRpcServerHandlerDispatch:
 
         # Mock allocation to fail
         monkeypatch.setattr(
-            server._allocation_manager, "allocate", lambda instance_id, size: None
+            server._allocation_manager, "allocate", lambda instance_id, size, pool_id=0xFFFFFFFF: None
         )
 
-        request = MockRequest(instance_id="instance1", size=4096)
+        request = MockRequest(instance_id="instance1", size=4096, pool_id=0xFFFFFFFF)
         response = rpc._handle_request_alloc(request)
 
         assert response["success"] is False
@@ -462,7 +462,7 @@ class TestRpcHandlerCoverage:
         server.register_kv(key="100", region_id=region_id, kv_offset=0, kv_length=256)
 
         # Test REQUEST_ALLOC
-        req = MockRequest(instance_id="instance2", size=2048)
+        req = MockRequest(instance_id="instance2", size=2048, pool_id=0xFFFFFFFF)
         resp = rpc._handle_message(MessageType.REQUEST_ALLOC.value, req)
         assert resp["success"] is True
 


### PR DESCRIPTION
## Summary
- Add `pool_id` configuration support through the entire stack: `MaruConfig → MaruHandler → RPC → MaruServer → AllocationManager → MaruShmClient.alloc()`
- Enables pinning memory allocations to specific dax devices (e.g., dax0.0 → pool 0, dax1.0 → pool 1)
- `pool_id: None` (default) uses `ANY_POOL_ID = 0xFFFFFFFF` for first-fit allocation across all pools

## Changes
- `maru_common/config.py`: Added `pool_id` field to `MaruConfig`
- `maru_common/protocol.py`: Added `pool_id` to `RequestAllocRequest` RPC message
- `maru_handler/handler.py`: Resolves and forwards `pool_id` through connect/expand
- `maru_handler/rpc_client.py`, `rpc_async_client.py`: Added `pool_id` param to `request_alloc()`
- `maru_server/server.py`, `allocation_manager.py`: Forward `pool_id` to `MaruShmClient.alloc()`
- `maru_server/rpc_handler_mixin.py`, `rpc_server.py`, `rpc_async_server.py`: Pass `pool_id` from RPC request
- All unit tests updated for new `pool_id` parameter

## Test plan
- [x] All 576 unit tests pass
- [x] Manual test: CXL (pool 0) and GAIA (pool 1) dax device pinning verified