### PR TITLE
ci: fix coverage comment on fork PRs

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,60 @@
+name: Coverage Comment
+
+on:
+  workflow_run:
+    workflows: ["Test"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Find PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const prs = context.payload.workflow_run.pull_requests;
+            if (prs && prs.length > 0) {
+              core.setOutput('number', prs[0].number);
+            } else {
+              // Fallback: search for PR by head SHA
+              const head_sha = context.payload.workflow_run.head_sha;
+              const { data } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                sort: 'updated',
+                direction: 'desc',
+                per_page: 10,
+              });
+              const pr = data.find(p => p.head.sha === head_sha);
+              if (pr) {
+                core.setOutput('number', pr.number);
+              } else {
+                core.setFailed('Could not find PR number');
+              }
+            }
+
+      - name: Coverage comment on PR
+        if: steps.pr.outputs.number
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-xml-coverage-path: coverage.xml
+          junitxml-path: pytest.xml
+          unique-id-for-comment: coverage-report
+          issue-number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,11 @@ jobs:
             --cov-report=xml:coverage.xml \
             --junitxml=pytest.xml \
             -v
-      - name: Coverage comment on PR
-        if: github.event_name == 'pull_request'
-        uses: MishaKav/pytest-coverage-comment@main
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          pytest-xml-coverage-path: coverage.xml
-          junitxml-path: pytest.xml
-          unique-id-for-comment: coverage-report
+          name: coverage-report
+          path: |
+            coverage.xml
+            pytest.xml


### PR DESCRIPTION
## Summary
- Split test workflow into two: `test.yml` (runs tests, uploads artifacts) and `coverage-comment.yml` (posts PR comment via `workflow_run`)
- Fixes permission denied error when `MishaKav/pytest-coverage-comment` tries to comment on fork PRs with read-only `GITHUB_TOKEN`
- `workflow_run` event runs in the base repo context with write permission, safely resolving the fork PR token limitation

## Details

The `pull_request` event gives fork PRs a read-only `GITHUB_TOKEN`, which prevents the coverage comment action from posting. The `workflow_run` approach:

1. `test.yml` runs tests and uploads `coverage.xml` / `pytest.xml` as artifacts
2. `coverage-comment.yml` triggers on `workflow_run` completion, downloads artifacts, finds the PR number, and posts the comment with full write permission

## Test plan
- [ ] Open a fork PR and verify coverage comment appears
- [ ] Verify non-fork PRs still get coverage comments
- [ ] Verify test workflow still runs and passes