### PR TITLE
feat: add pool monitor tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ extra_config:
 For full configuration details, see the [documentation](https://xcena-dev.github.io/maru-dev/source/getting_started/examples/lmcache/).
 
 
+## Tools
+
+- **[pool_monitor](tools/)** — Real-time pool usage monitor (`top`-style TUI, CSV export)
+
 ## License
 
 Copyright 2026 [XCENA Inc.](https://xcena.com) Licensed under the Apache License 2.0.

--- a/tools/README.md
+++ b/tools/README.md
@@ -11,3 +11,26 @@ python tools/pool_monitor.py -w 1 -c 30   # watch 30 times at 1s interval
 python tools/pool_monitor.py --csv        # CSV output for post-processing
 python tools/pool_monitor.py --scroll     # scrolling log (no screen clear)
 ```
+
+### Example Output
+
+**TUI mode** (`-w 1`):
+
+```
+  Maru Pool Monitor  —  2026-03-11T14:30:05  (Ctrl+C to quit)
+
+  Pool  Type      Used      Free     Total     Delta  Usage
+  ----  --------  --------  --------  --------  --------  -----
+     0  DEV_DAX     13.8G    229.0G    242.8G            [##----------------------------] 5.7%
+     1  DEV_DAX   3319.5G     13.8G   3333.2G   +100.0G  [#############################-] 99.6%
+     2  DEV_DAX     13.8G    215.2G    229.0G            [##----------------------------] 6.0%
+     3  DEV_DAX       0B     229.0G    229.0G            [------------------------------] 0.0%
+```
+
+**CSV mode** (`--csv`):
+
+```
+timestamp,pool_id,dax_type,total_bytes,free_bytes,used_bytes,usage_pct
+2026-03-11T14:30:05,0,DEV_DAX,260717199360,245861867520,14855331840,5.70
+2026-03-11T14:30:05,1,DEV_DAX,3578455826432,14855331840,3563600494592,99.58
+```

--- a/tools/pool_monitor.py
+++ b/tools/pool_monitor.py
@@ -18,6 +18,8 @@ from maru_shm import MaruShmClient
 
 
 def _fmt_size(nbytes: int) -> str:
+    if nbytes == 0:
+        return "0B"
     if nbytes >= 1024**4:
         return f"{nbytes / 1024**4:.1f}T"
     if nbytes >= 1024**3:
@@ -35,7 +37,7 @@ def _usage_bar(used: int, total: int, width: int = 30) -> str:
     return "[" + "#" * filled + "-" * (width - filled) + f"] {ratio * 100:.1f}%"
 
 
-def snapshot(client: MaruShmClient) -> list:
+def snapshot(client: MaruShmClient) -> list[object]:
     return client.stats()
 
 
@@ -44,7 +46,9 @@ def _clear_screen() -> None:
     sys.stdout.flush()
 
 
-def render_table(pools: list, ts: str, prev: dict | None = None) -> str:
+def render_table(
+    pools: list[object], ts: str, prev: dict[int, int] | None = None
+) -> str:
     """Render table to string. prev maps pool_id -> previous used bytes for delta."""
     lines = []
     lines.append(f"  Maru Pool Monitor  —  {ts}  (Ctrl+C to quit)")
@@ -82,7 +86,7 @@ def print_csv_header() -> None:
     print("timestamp,pool_id,dax_type,total_bytes,free_bytes,used_bytes,usage_pct")
 
 
-def print_csv_row(pools: list, ts: str) -> None:
+def print_csv_row(pools: list[object], ts: str) -> None:
     for p in sorted(pools, key=lambda x: x.pool_id):
         used = p.total_size - p.free_size
         pct = (used / p.total_size * 100) if p.total_size > 0 else 0
@@ -115,7 +119,11 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    client = MaruShmClient()
+    try:
+        client = MaruShmClient()
+    except Exception as e:
+        print(f"Error: cannot connect to maru_resourced: {e}", file=sys.stderr)
+        sys.exit(1)
 
     if args.watch <= 0:
         # One-shot
@@ -137,7 +145,12 @@ def main() -> None:
     try:
         while True:
             ts = datetime.now().isoformat(timespec="seconds")
-            pools = snapshot(client)
+            try:
+                pools = snapshot(client)
+            except Exception as e:
+                print(f"  [error] {e}", file=sys.stderr)
+                time.sleep(args.watch)
+                continue
             if args.csv:
                 print_csv_row(pools, ts)
                 sys.stdout.flush()


### PR DESCRIPTION
## Summary
- Add `tools/pool_monitor.py` for real-time maru memory pool usage monitoring
- Supports top-style TUI refresh (`-w 1`), CSV export (`--csv`), and scrolling log (`--scroll`)
- Shows per-pool usage bars, delta tracking between intervals

## Usage
```bash
python tools/pool_monitor.py              # one-shot snapshot
python tools/pool_monitor.py -w 1         # top-style refresh every 1s
python tools/pool_monitor.py --csv        # CSV output for post-processing
```

## Test plan
- [ ] Run one-shot mode and verify pool stats match `MaruShmClient().stats()`
- [ ] Run watch mode with `-w 1` and verify live updates
- [ ] Run CSV mode and verify parseable output