### PR TITLE
fix: correct LMCache documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ extra_config:
   maru_pool_size: "4G"
 ```
 
-For full configuration details, see the [documentation](https://xcena-dev.github.io/maru-dev/source/getting_started/examples/lmcache/).
+For details on LMCache integration, see the [documentation](https://xcena-dev.github.io/maru/source/integration/lmcache.html).
 
 
 ## License


### PR DESCRIPTION
## Summary
- Fix broken documentation URL in the LMCache Integration section (`maru-dev` → `maru`)
- Clarify link description to specifically reference LMCache integration

## Test plan
- [x] Verify the updated link resolves correctly