### PR TITLE
ci: add Claude PR review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,7 +9,5 @@ jobs:
   review:
     uses: xcena-dev/.github/.github/workflows/claude-review.yml@main
     with:
-      language: "ko"
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      METISX_GIT_ACTION_ACCESS_TOKEN: ${{ secrets.METISX_GIT_ACTION_ACCESS_TOKEN }}
+      model: "claude-opus-4-6"
+    secrets: inherit

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,15 @@
+# .github/workflows/claude-review.yml
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  review:
+    uses: xcena-dev/.github/.github/workflows/claude-review.yml@main
+    with:
+      language: "ko"
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      METISX_GIT_ACTION_ACCESS_TOKEN: ${{ secrets.METISX_GIT_ACTION_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

PR open/update 시 Claude가 자동으로 코드 리뷰를 수행하는 GitHub Actions workflow를 추가합니다. xcena-dev/.github의 shared workflow를 사용하여 일관된 리뷰 환경을 제공합니다.

## Key Changes

- `.github/workflows/claude-review.yml` 추가
  - PR `opened`, `synchronize` 이벤트에서 트리거
  - `xcena-dev/.github`의 shared workflow(`claude-review.yml@main`) 재사용
  - 리뷰 언어: 한국어(`language: "ko"`)
  - `ANTHROPIC_API_KEY`, `METISX_GIT_ACTION_ACCESS_TOKEN` secrets 전달

## Test Plan

- [ ] Unit tests added/updated
- [ ] Existing tests pass (`pytest -v`)
- [ ] E2E tests (if applicable)

## Related Issues