### PR TITLE
ci: inline claude-review workflow for public repo

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
-      GH_TOKEN: ${{ secrets.GH_PAT }}
+      GH_TOKEN: ${{ github.token }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.GH_PAT }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,4 +1,3 @@
-# .github/workflows/claude-review.yml
 name: Claude PR Review
 
 on:
@@ -7,7 +6,143 @@ on:
 
 jobs:
   review:
-    uses: xcena-dev/.github/.github/workflows/claude-review.yml@main
-    with:
-      model: "claude-opus-4-6"
-    secrets: inherit
+    if: "!contains(github.head_ref || '', 'ci_sync')"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
+      GH_TOKEN: ${{ secrets.METISX_GIT_ACTION_ACCESS_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.METISX_GIT_ACTION_ACCESS_TOKEN }}
+
+      - name: Install dependencies
+        run: |
+          curl -fsSL https://deb.nodesource.com/setup_20.x | sudo bash -
+          sudo apt-get install -y -qq nodejs
+          npm install -g @anthropic-ai/claude-code
+
+      - name: Claude PR Review
+        id: claude-review
+        continue-on-error: true
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          LANG_OPT: "en"
+          ADDITIONAL_PROMPT: ""
+          CLAUDE_MODEL: "claude-opus-4-6"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "=== Claude PR Review ==="
+          echo "  PR: #${PR_NUMBER} in ${REPO}"
+
+          PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json title,headRefOid)
+          PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+          PR_HEAD=$(echo "$PR_JSON" | jq -r '.headRefOid' | cut -c1-7)
+
+          if [ "$LANG_OPT" = "ko" ]; then
+          PROMPT="당신은 탁월한 통찰력을 가진 10년 차 시니어 소프트웨어 엔지니어입니다.
+
+          ${ADDITIONAL_PROMPT:+**[🔥 중요: 특별 부여 페르소나 및 추가 리뷰 기준]**
+          ${ADDITIONAL_PROMPT}
+
+          }이 PR의 코드 변경사항에 대해 꼼꼼하고 건설적인 코드 리뷰를 진행해 주세요.
+
+          PR #${PR_NUMBER} in ${REPO}
+          Title: ${PR_TITLE}
+          Commit SHA: ${PR_HEAD}
+
+          [작업 단계]
+          1. 'gh pr diff ${PR_NUMBER} --repo ${REPO}' 명령어로 변경 사항을 꼼꼼히 확인하세요.
+          2. 코드를 분석하여 전체적인 리뷰(Summary)와 특정 라인에 대한 인라인 리뷰(Inline Comments)를 도출하세요.
+             - [중요]: 인라인 코멘트를 작성할 때는 반드시 diff 상에 존재하는 유효한 파일 경로(path)와 변경된 정확한 줄 번호(line)를 파악해야 합니다.
+             - [예외 처리]: 만약 정확한 줄 번호를 파악하기 어렵다면, 해당 내용을 'comments' 배열에 넣지 말고 전체 리뷰('body') 하단에 텍스트로 남겨주세요.
+          3. 코드 변경 사항 중 로직이나 아키텍처 플로우가 변경된 핵심 부분이 있다면, Markdown의 \`mermaid\` 문법을 사용하여 '변경 전(Before)'과 '변경 후(After)'를 비교하는 다이어그램을 작성하세요. 변경이 단순하면 생략해도 됩니다.
+          4. 분석 결과를 바탕으로 아래 예시와 같은 구조의 JSON 파일을 'review.json' 이라는 이름으로 생성하세요. JSON 문자열 내의 줄바꿈은 반드시 '\\n'으로 처리해야 합니다.
+
+          [JSON 파일 (review.json) 구조 예시]
+          {
+            \"commit_id\": \"${PR_HEAD}\",
+            \"event\": \"COMMENT\",
+            \"body\": \"## 🛠️ AI Code Review\\n**Reviewed at commit:** \`${PR_HEAD}\`\\n\\n### 📊 Summary\\n<3-4줄 전체 평가 요약 및 주요 칭찬 포인트>\\n\\n### 🔄 Architecture & Flow Changes\\n\`\`\`mermaid\\ngraph TD\\n  subgraph Before\\n    A1[기존 로직] --> B1[기존 흐름]\\n  end\\n  subgraph After\\n    A2[새 로직] --> B2[개선된 흐름]\\n  end\\n\`\`\`\\n\\n### 📝 추가 코멘트\\n<인라인으로 달기 애매한 아키텍처 설계 피드백이나 기타 의견들>\",
+            \"comments\": [
+              {
+                \"path\": \"src/main.c\",
+                \"line\": 42,
+                \"body\": \"#### [suggestion] 로직 개선\\n이 부분에서 문제가 발생할 수 있습니다. 다음과 같이 수정하는 것을 권장합니다.\\n\`\`\`c\\n...\\n\`\`\`\"
+              }
+            ]
+          }
+
+          5. 'review.json' 생성이 완료되면 터미널에서 아래 명령어를 실행하여 PR에 리뷰를 등록하세요:
+          gh api -X POST repos/${REPO}/pulls/${PR_NUMBER}/reviews --input review.json
+
+          6. 완료 후 'review.json' 파일을 삭제하세요."
+          else
+          PROMPT="You are an exceptionally insightful 10-year senior software engineer.
+
+          ${ADDITIONAL_PROMPT:+**[🔥 IMPORTANT: Assigned Persona & Additional Criteria]**
+          ${ADDITIONAL_PROMPT}
+
+          }Provide a thorough and constructive code review for this PR.
+
+          Title: ${PR_TITLE}
+          Commit SHA: ${PR_HEAD}
+
+          [Steps]
+          1. Run 'gh pr diff ${PR_NUMBER} --repo ${REPO}' to check the changes.
+          2. Analyze the code to provide an overall summary and specific inline comments.
+             - [Important]: For inline comments, identify the exact file 'path' and valid 'line' number from the diff.
+             - [Fallback]: If unsure about the exact line number, include your feedback in the overall review ('body') instead of the 'comments' array.
+          3. If there are core logic or architectural flow changes, use Markdown's \`mermaid\` syntax to create 'Before' and 'After' comparison diagrams. Skip if changes are trivial.
+          4. Create a JSON file named 'review.json' with the exact structure below. Remember to escape newlines as '\\n' in the JSON string.
+
+          [JSON Format Example (review.json)]
+          {
+            \"commit_id\": \"${PR_HEAD}\",
+            \"event\": \"COMMENT\",
+            \"body\": \"## 🛠️ AI Code Review\\n**Reviewed at commit:** \`${PR_HEAD}\`\\n\\n### 📊 Summary\\n<Overall summary and praise points>\\n\\n### 🔄 Architecture & Flow Changes\\n\`\`\`mermaid\\ngraph TD\\n  subgraph Before\\n    A1[Old Logic] --> B1[Old Flow]\\n  end\\n  subgraph After\\n    A2[New Logic] --> B2[Improved Flow]\\n  end\\n\`\`\`\\n\\n### 📝 Additional Feedback\\n<Architectural feedback or comments not attached inline>\",
+            \"comments\": [
+              {
+                \"path\": \"src/main.c\",
+                \"line\": 42,
+                \"body\": \"#### [suggestion] Logic improvement\\nConsider changing this to avoid issues.\\n\`\`\`c\\n...\\n\`\`\`\"
+              }
+            ]
+          }
+
+          5. Once 'review.json' is created, run this command to post the review:
+          gh api -X POST repos/${REPO}/pulls/${PR_NUMBER}/reviews --input review.json
+
+          6. Delete 'review.json' after successful execution."
+          fi
+
+          echo "=== Running Claude CLI ==="
+          echo "$PROMPT" | claude -p --model ${CLAUDE_MODEL} --verbose --dangerously-skip-permissions --output-format stream-json 2>&1 | tee /tmp/claude_output.log
+          echo "=== Review complete ==="
+
+      - name: Report failure to PR
+        if: steps.claude-review.outcome == 'failure'
+        run: |
+          PR_NUM=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          LAST_LINES=""
+          if [ -f /tmp/claude_output.log ]; then
+            LAST_LINES=$(tail -20 /tmp/claude_output.log)
+          fi
+          gh pr comment "$PR_NUM" --repo "$REPO" --body "$(cat <<EOF
+          Claude PR Review failed
+
+          **Run:** ${RUN_URL}
+
+          \`\`\`
+          ${LAST_LINES}
+          \`\`\`
+          EOF
+          )"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,7 @@
 name: Claude PR Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,12 +11,10 @@ jobs:
     timeout-minutes: 15
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
-      GH_TOKEN: ${{ secrets.METISX_GIT_ACTION_ACCESS_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_PAT }}
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.METISX_GIT_ACTION_ACCESS_TOKEN }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- Shared workflow (`xcena-dev/.github`) is not accessible from public repos due to secret/runner restrictions
- Inline the Claude PR Review step directly with `ubuntu-latest` runner
- Install only required dependencies (Node.js 20 + Claude CLI); `gh`, `git`, `jq` are pre-installed on `ubuntu-latest`
- Prompt content is identical to the shared template

## Changes
- `.github/workflows/claude-review.yml`: Replace `uses: xcena-dev/.github/...` with inlined workflow

## Test plan
- [ ] Verify workflow triggers on PR open/synchronize
- [ ] Verify Claude CLI authenticates with `ANTHROPIC_API_KEY`
- [ ] Verify review is posted as PR comment