### PR TITLE
fix: auto-rescan DAX devices when pool is empty on startup

### DIFF
--- a/maru_resource_manager/src/main.cpp
+++ b/maru_resource_manager/src/main.cpp
@@ -76,10 +76,18 @@ int main(int argc, char **argv) {
                cfg.host.c_str(), cfg.port);
 
     // Main loop — runs until SIGINT/SIGTERM
+    auto lastRescan = std::chrono::steady_clock::now();
     while (!gStop) {
         if (gRescan) {
             gRescan = 0;
             pm.rescanDevices();
+            lastRescan = std::chrono::steady_clock::now();
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        if (now - lastRescan > std::chrono::seconds(10)) {
+            pm.rescanIfEmpty();
+            lastRescan = now;
         }
 
         std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/maru_resource_manager/src/main.cpp
+++ b/maru_resource_manager/src/main.cpp
@@ -52,9 +52,7 @@ int main(int argc, char **argv) {
     }
     // loadPools returns 0 even when no devices found (scanDevices succeeds
     // with empty list). Check actual pool state for auto-rescan decision.
-    std::vector<maru::PoolState> stats;
-    pm.getStats(stats);
-    bool needsRescan = stats.empty();
+    bool needsRescan = !pm.hasPools();
     if (needsRescan) {
         maru::logf(maru::LogLevel::Warn,
                     "no CXL/DAX devices found — starting with empty pool");
@@ -103,6 +101,9 @@ int main(int argc, char **argv) {
                     maru::logf(maru::LogLevel::Info,
                                "CXL/DAX devices found, auto-rescan complete");
                     needsRescan = false;
+                } else if (ret < 0) {
+                    maru::logf(maru::LogLevel::Warn,
+                               "auto-rescan failed (rc=%d), will retry", ret);
                 }
             }
         }

--- a/maru_resource_manager/src/main.cpp
+++ b/maru_resource_manager/src/main.cpp
@@ -48,6 +48,14 @@ int main(int argc, char **argv) {
     maru::PoolManager pm(cfg.stateDir, cfg.gracePeriodSec);
     int rc = pm.loadPools();
     if (rc != 0) {
+        maru::logf(maru::LogLevel::Error, "loadPools failed (rc=%d)", rc);
+    }
+    // loadPools returns 0 even when no devices found (scanDevices succeeds
+    // with empty list). Check actual pool state for auto-rescan decision.
+    std::vector<maru::PoolState> stats;
+    pm.getStats(stats);
+    bool needsRescan = stats.empty();
+    if (needsRescan) {
         maru::logf(maru::LogLevel::Warn,
                     "no CXL/DAX devices found — starting with empty pool");
     }
@@ -84,10 +92,19 @@ int main(int argc, char **argv) {
             lastRescan = std::chrono::steady_clock::now();
         }
 
-        auto now = std::chrono::steady_clock::now();
-        if (now - lastRescan > std::chrono::seconds(10)) {
-            pm.rescanIfEmpty();
-            lastRescan = now;
+        if (needsRescan) {
+            auto now = std::chrono::steady_clock::now();
+            if (now - lastRescan > std::chrono::seconds(10)) {
+                maru::logf(maru::LogLevel::Info,
+                           "pools empty, rescanning for CXL/DAX devices...");
+                int ret = pm.rescanIfEmpty();
+                lastRescan = now;
+                if (ret > 0) {
+                    maru::logf(maru::LogLevel::Info,
+                               "CXL/DAX devices found, auto-rescan complete");
+                    needsRescan = false;
+                }
+            }
         }
 
         std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/maru_resource_manager/src/pool_manager.cpp
+++ b/maru_resource_manager/src/pool_manager.cpp
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <map>
 #include <unordered_set>
 
 #include "device_header.h"
@@ -456,8 +457,8 @@ int PoolManager::getDeviceSize(const std::string &path, uint64_t &sizeOut)
     return -ENOTSUP;
 }
 
-int PoolManager::loadPoolFromDevice(uint32_t poolId, const std::string &path,
-                                    DaxType type)
+int PoolManager::buildPoolFromDevice(uint32_t poolId, const std::string &path,
+                                      DaxType type, PoolState &out)
 {
     uint64_t size = 0;
     int rc = getDeviceSize(path, size);
@@ -549,7 +550,20 @@ int PoolManager::loadPoolFromDevice(uint32_t poolId, const std::string &path,
         pool = loaded;
     }
 
-    pools_.push_back(pool);
+    out = std::move(pool);
+    return 0;
+}
+
+int PoolManager::loadPoolFromDevice(uint32_t poolId, const std::string &path,
+                                    DaxType type)
+{
+    PoolState pool;
+    int rc = buildPoolFromDevice(poolId, path, type, pool);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    pools_.push_back(std::move(pool));
     return 0;
 }
 
@@ -596,22 +610,29 @@ int PoolManager::loadPoolsLocked()
         return rc;
     }
 
-    pools_.clear();
-    allocations_.clear();
-    nextRegionId_ = 1;
-
+    // Stage everything in scratch state. Commit only after WAL replay succeeds
+    // so a partial replay cannot leave pools_/allocations_ in an inconsistent
+    // state visible to clients.
+    std::vector<PoolState> stagedPools;
     for (const auto &dev : devices)
     {
-        rc = loadPoolFromDevice(dev.poolId, dev.devPath, dev.type);
+        PoolState pool;
+        rc = buildPoolFromDevice(dev.poolId, dev.devPath, dev.type, pool);
         if (rc != 0)
         {
-            logf(LogLevel::Warn, "maru-resource-manager: failed to load pool %u from %s: %d", dev.poolId, dev.devPath.c_str(), rc);
+            logf(LogLevel::Warn,
+                 "maru-resource-manager: failed to load pool %u from %s: %d",
+                 dev.poolId, dev.devPath.c_str(), rc);
+            continue;
         }
+        stagedPools.push_back(std::move(pool));
     }
 
-    metadata_->loadGlobal(allocations_, nextRegionId_);
+    std::map<uint64_t, Allocation> stagedAllocations;
+    uint64_t stagedNextRegionId = 1;
+    metadata_->loadGlobal(stagedAllocations, stagedNextRegionId);
 
-    int walRc = wal_->replay(pools_, allocations_, nextRegionId_);
+    int walRc = wal_->replay(stagedPools, stagedAllocations, stagedNextRegionId);
     if (walRc != 0 && walRc != -ENOENT)
     {
         logf(LogLevel::Error, "loadPools: WAL replay failed: %d", walRc);
@@ -621,17 +642,20 @@ int PoolManager::loadPoolsLocked()
     // Recompute auth tokens for all restored allocations.
     // Tokens now include client_id in the HMAC input; legacy tokens
     // (computed without client_id) would fail verification after this change.
-    for (auto &[regionId, alloc] : allocations_)
+    for (auto &[regionId, alloc] : stagedAllocations)
     {
         alloc.handle.authToken = computeAuthToken(
             alloc.handle, alloc.nonce, std::string(alloc.clientId));
     }
 
-    for (auto &pool : pools_)
+    for (auto &pool : stagedPools)
     {
         recomputeFreeSize(pool);
     }
 
+    pools_ = std::move(stagedPools);
+    allocations_ = std::move(stagedAllocations);
+    nextRegionId_ = stagedNextRegionId;
     return 0;
 }
 
@@ -644,7 +668,8 @@ int PoolManager::rescanDevicesLocked()
         return rc;
     }
 
-    size_t oldSize = pools_.size();
+    // Build new pools in scratch space without touching pools_.
+    std::vector<PoolState> stagedPools;
     for (const auto &dev : devices)
     {
         bool exists = false;
@@ -660,7 +685,8 @@ int PoolManager::rescanDevicesLocked()
         {
             continue;
         }
-        rc = loadPoolFromDevice(dev.poolId, dev.devPath, dev.type);
+        PoolState pool;
+        rc = buildPoolFromDevice(dev.poolId, dev.devPath, dev.type, pool);
         if (rc != 0)
         {
             logf(LogLevel::Warn,
@@ -668,26 +694,34 @@ int PoolManager::rescanDevicesLocked()
                  dev.devPath.c_str(), rc);
             continue;
         }
+        stagedPools.push_back(std::move(pool));
     }
 
-    if (pools_.size() == oldSize)
+    if (stagedPools.empty())
     {
         return 0;
     }
 
-    std::vector<PoolState> newPools(
-        pools_.begin() + static_cast<std::ptrdiff_t>(oldSize),
-        pools_.end());
-    int walRc = wal_->replay(newPools, allocations_, nextRegionId_);
+    // Snapshot global mutable state. WAL replay mutates allocations_ and
+    // nextRegionId_ by reference and may fail mid-stream, so we need rollback.
+    auto allocSnapshot = allocations_;
+    uint64_t nextRegionIdSnapshot = nextRegionId_;
+
+    int walRc = wal_->replay(stagedPools, allocations_, nextRegionId_);
     if (walRc != 0 && walRc != -ENOENT)
     {
+        allocations_ = std::move(allocSnapshot);
+        nextRegionId_ = nextRegionIdSnapshot;
+        logf(LogLevel::Error,
+             "rescan: WAL replay failed: %d, rolled back", walRc);
         return walRc;
     }
 
-    for (size_t i = 0; i < newPools.size(); ++i)
+    // Commit only after replay succeeds.
+    for (auto &pool : stagedPools)
     {
-        recomputeFreeSize(newPools[i]);
-        pools_[oldSize + i] = std::move(newPools[i]);
+        recomputeFreeSize(pool);
+        pools_.push_back(std::move(pool));
     }
 
     return 0;

--- a/maru_resource_manager/src/pool_manager.cpp
+++ b/maru_resource_manager/src/pool_manager.cpp
@@ -565,6 +565,16 @@ int PoolManager::rescanDevices()
     return rescanDevicesLocked();
 }
 
+int PoolManager::rescanIfEmpty()
+{
+    std::lock_guard<std::mutex> lock(mu_);
+    if (!pools_.empty())
+    {
+        return 0;
+    }
+    return rescanDevicesLocked();
+}
+
 int PoolManager::loadPoolsLocked()
 {
     std::vector<DeviceInfo> devices;
@@ -640,7 +650,10 @@ int PoolManager::rescanDevicesLocked()
         rc = loadPoolFromDevice(dev.poolId, dev.devPath, dev.type);
         if (rc != 0)
         {
-            return rc;
+            logf(LogLevel::Warn,
+                 "rescan: failed to load pool from %s: %d",
+                 dev.devPath.c_str(), rc);
+            continue;
         }
     }
 

--- a/maru_resource_manager/src/pool_manager.cpp
+++ b/maru_resource_manager/src/pool_manager.cpp
@@ -565,6 +565,12 @@ int PoolManager::rescanDevices()
     return rescanDevicesLocked();
 }
 
+bool PoolManager::hasPools() const
+{
+    std::lock_guard<std::mutex> lock(mu_);
+    return !pools_.empty();
+}
+
 int PoolManager::rescanIfEmpty()
 {
     std::lock_guard<std::mutex> lock(mu_);

--- a/maru_resource_manager/src/pool_manager.cpp
+++ b/maru_resource_manager/src/pool_manager.cpp
@@ -570,9 +570,14 @@ int PoolManager::rescanIfEmpty()
     std::lock_guard<std::mutex> lock(mu_);
     if (!pools_.empty())
     {
-        return 0;
+        return 1;
     }
-    return rescanDevicesLocked();
+    int rc = rescanDevicesLocked();
+    if (rc != 0)
+    {
+        return rc;
+    }
+    return pools_.empty() ? 0 : 1;
 }
 
 int PoolManager::loadPoolsLocked()
@@ -581,6 +586,7 @@ int PoolManager::loadPoolsLocked()
     int rc = scanDevices(devices);
     if (rc != 0)
     {
+        logf(LogLevel::Error, "loadPools: device scan failed: %d", rc);
         return rc;
     }
 
@@ -602,6 +608,7 @@ int PoolManager::loadPoolsLocked()
     int walRc = wal_->replay(pools_, allocations_, nextRegionId_);
     if (walRc != 0 && walRc != -ENOENT)
     {
+        logf(LogLevel::Error, "loadPools: WAL replay failed: %d", walRc);
         return walRc;
     }
 

--- a/maru_resource_manager/src/pool_manager.h
+++ b/maru_resource_manager/src/pool_manager.h
@@ -99,6 +99,11 @@ private:
     };
 
     int scanDevices(std::vector<DeviceInfo> &outDevices);
+    // Pure builder: constructs a PoolState from device without touching pools_.
+    // Caller decides when to commit. Disk side effects (UUID header init) may
+    // still happen and are idempotent.
+    int buildPoolFromDevice(uint32_t poolId, const std::string &path,
+                            DaxType type, PoolState &out);
     int loadPoolFromDevice(uint32_t poolId, const std::string &path,
                            DaxType type);
     int getDeviceSize(const std::string &path, uint64_t &sizeOut);

--- a/maru_resource_manager/src/pool_manager.h
+++ b/maru_resource_manager/src/pool_manager.h
@@ -61,6 +61,8 @@ public:
 
     int loadPools();
     int rescanDevices();
+    /// Rescan devices only if no pools are loaded.
+    /// Returns: 1 = pools available, 0 = still empty, negative = error.
     int rescanIfEmpty();
     int alloc(uint64_t size, const std::string &clientId, Handle &out,
               std::string &devPath, std::string &deviceUuid,

--- a/maru_resource_manager/src/pool_manager.h
+++ b/maru_resource_manager/src/pool_manager.h
@@ -74,6 +74,8 @@ public:
     int verifyAndGetPath(const Handle &handle, std::string &outPath);
 
     void getStats(std::vector<PoolState> &out);
+    /// Lightweight check: returns true if at least one pool is loaded.
+    bool hasPools() const;
     int getPathForHandle(const Handle &handle, std::string &outPath);
     bool hasExistingAllocations();
 

--- a/maru_resource_manager/src/pool_manager.h
+++ b/maru_resource_manager/src/pool_manager.h
@@ -61,6 +61,7 @@ public:
 
     int loadPools();
     int rescanDevices();
+    int rescanIfEmpty();
     int alloc(uint64_t size, const std::string &clientId, Handle &out,
               std::string &devPath, std::string &deviceUuid,
               const std::string &daxPath, uint64_t &requestedSizeOut);

--- a/maru_resource_manager/tests/test_pool_manager_uuid.cpp
+++ b/maru_resource_manager/tests/test_pool_manager_uuid.cpp
@@ -49,3 +49,4 @@ TEST_F(PoolManagerUuidTest, GetStatsEmptyPools) {
     pm_->getStats(stats);
     EXPECT_TRUE(stats.empty());
 }
+


### PR DESCRIPTION
## Background & Motivation

- When RM is auto-started by systemd on boot, the kernel's CXL/DAX device probe (driver bind → sysfs entry creation) may not yet be complete. In that case, `scanDevices()` finds no entries in `/sys/bus/dax/devices/`, returning an empty result and leaving `pools_` empty for the lifetime of the process.
- All subsequent ALLOC requests fail with `status=-19` (ENODEV), with no automatic recovery path until manual `systemctl restart` or `kill -HUP`.
- The existing `After=network.target` in the service file is unrelated to DAX device readiness — there is no systemd ordering guarantee against CXL driver probe timing, creating a boot-order race condition.
- Additional finding: the initial implementation used `needsRescan = (rc != 0)`, but `loadPools()` → `scanDevices()` returns 0 (success) even with zero devices, making the auto-rescan path permanently dead code.

## Design Changes

- **Critical fix**: Changed `needsRescan` detection from return code (`rc != 0`) to actual pool state (`getStats().empty()`)
- **API redesign**: `rescanIfEmpty()` return value redesigned to tri-state — `1` = pools available, `0` = still empty, `negative` = error
- **Conditional polling**: Auto-rescan runs at 10s intervals only when pool is empty; polling stops automatically once devices are found (`needsRescan = false`)
- **Error logging**: `loadPoolsLocked()` now logs specific failure cause internally (device scan vs WAL replay); caller (`main.cpp`) only records the failure fact
- **Resilience**: `rescanDevicesLocked()` changed from `return rc` to `warn + continue` on single device load failure

```
Before: main loop
  └─ rescan only on SIGHUP (manual)
  └─ needsRescan = (rc != 0)  ← loadPools returns 0 even with empty list → dead code

After: main loop
  ├─ rescan on SIGHUP (manual)
  └─ needsRescan = getStats().empty()  ← checks actual pool state
     └─ polls rescanIfEmpty() at 10s intervals only when true
     └─ rescanIfEmpty() returns 1 → needsRescan = false (polling stops)
```

## Implementation Details

### 1. `rescanDevicesLocked()` early return fix (`pool_manager.cpp`)
- `loadPoolFromDevice()` failure: `return rc` → `logf(Warn) + continue`
- Previously, if device B failed among devices A, B, C, device C was never attempted, and WAL replay + `recomputeFreeSize()` for device A were skipped, leaving pool state incomplete
- Now consistent with the same pattern (warn + continue) used in `loadPoolsLocked()`

### 2. `rescanIfEmpty()` tri-state return value (`pool_manager.cpp`, `pool_manager.h`)
- Acquires `mu_` once, checks `pools_.empty()`, then calls `rescanDevicesLocked()`
- Returns: `1` = pools available (already existed or found by rescan), `0` = still empty after rescan, `negative` = error
- Immediate `return 1` if pools already exist — minimizes lock hold time

### 3. `needsRescan` detection change (`main.cpp`)
- Uses `pm.getStats(stats)` → `stats.empty()` instead of `loadPools()` return code
- `loadPools()` → `scanDevices()` returns 0 (success) even with an empty device list, so return code-based detection was fundamentally the wrong abstraction level

### 4. Error log separation (`pool_manager.cpp`, `main.cpp`)
- `loadPoolsLocked()` logs specific failure cause at the point of failure:
  - `scanDevices()` failure: `"loadPools: device scan failed: %d"`
  - `wal_->replay()` failure: `"loadPools: WAL replay failed: %d"`
- `main.cpp` logs only the failure fact: `"loadPools failed (rc=%d)"`

### 5. Conditional auto-rescan in main loop (`main.cpp`)
- Polls at 10s intervals only when `needsRescan` is true
- `rescanIfEmpty()` returning `> 0` sets `needsRescan = false`, stopping polling entirely
- `lastRescan` is also reset after SIGHUP rescan to prevent redundant rescans

## Tests
- [x] Unit tests — all 16 existing tests pass
  - RM unit tests will be added after refactoring with proper mocking infrastructure in a separate PR 
- [x] Integration tests
- [x] Manual tests
  - Verified that the auto-rescan works correctly on server reboot

## Known Limitations
- `needsRescan` never transitions back to `true` once set to `false` — auto-rescan does not reactivate after runtime device hot-unplug (manual SIGHUP rescan still works). Tracked as a separate issue.

## Release Note
### NEW
- RM: Added automatic device rescan when pool is empty on startup (10s interval, stops after devices found)
### FIXED
- RM: Fixed `needsRescan` detection — was using `loadPools()` return code which returns 0 even with no devices, making auto-rescan dead code
- RM: Fixed `rescanDevicesLocked()` early return that skipped remaining devices and left pool state incomplete when a single device failed to load