### PR TITLE
fix: support latest vLLM KV cache layout

### DIFF
--- a/maru_vllm/connector.py
+++ b/maru_vllm/connector.py
@@ -685,7 +685,11 @@ class MaruWorkerConnector:
                 if kv_cache_attr is None:
                     continue
 
-                kv_cache_layer = kv_cache_attr[forward_context.virtual_engine]
+                if isinstance(kv_cache_attr, (list, tuple)):
+                    virtual_engine = getattr(forward_context, "virtual_engine", 0)
+                    kv_cache_layer = kv_cache_attr[virtual_engine]
+                else:
+                    kv_cache_layer = kv_cache_attr
                 # Use the same layer index derivation as save path
                 # to ensure key consistency (enumerate index may diverge
                 # when no_compile_layers contains non-attention layers).


### PR DESCRIPTION
## 🤔 Background & Motivation (Why)
- Latest vLLM versions no longer expose `ForwardContext.virtual_engine` on the load path.
- The Maru vLLM connector currently assumes `layer.kv_cache` is indexed by `forward_context.virtual_engine`, which crashes when a repeated prompt hits Maru and `start_load_kv()` runs.
- Reproduced with vLLM 0.22.0 after disabling the unrelated FlashInfer sampler startup issue via `VLLM_USE_FLASHINFER_SAMPLER=0`.

## 🏗️ Design Changes
- Behavioral change: `MaruWorkerConnector.start_load_kv()` now supports both older list/tuple KV cache containers and newer direct tensor-style `layer.kv_cache` values.
- No public API change.

## 📝 Implementation Details
- If `layer.kv_cache` is a list or tuple, keep the previous virtual-engine indexing behavior.
- Use `getattr(forward_context, "virtual_engine", 0)` so older layouts without the field still fall back to virtual engine 0.
- If `layer.kv_cache` is already a tensor, use it directly for KV injection.

## ✅ Tests
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] No tests needed (reason:                )

Manual validation:
- `python -m py_compile maru_vllm/connector.py`

Note: `pytest -q maru-private/tests/unit/test_vllm_connector.py` was not runnable in `~/.venv_vllm_latest` because the local test conftest requires `maru_shm`, which is not installed in that environment.

## 🔗 Related Issues (optional)
-

## 🌿 Related PRs (optional)
-

## 🌿 Related Branches (optional)
-

## 📦 Release Note (for auto-generation / write in English)
### NEW
-
### CHANGED
-
### FIXED
- Maru vLLM connector now handles latest vLLM KV cache layouts that do not expose `ForwardContext.virtual_engine`.
### IMPORTANT NOTES
-
