### PR TITLE
feat: per-instance CXL usage monitor (tools/usage_monitor.py)

### DIFF
--- a/maru_common/__init__.py
+++ b/maru_common/__init__.py
@@ -30,8 +30,11 @@ from .protocol import (  # noqa: E402
     ExistsKVResponse,
     GetStatsRequest,
     GetStatsResponse,
+    GetUsageRequest,
+    GetUsageResponse,
     HandshakeRequest,
     HandshakeResponse,
+    InstanceUsage,
     KVManagerStats,
     ListAllocationsRequest,
     ListAllocationsResponse,
@@ -102,6 +105,9 @@ __all__ = [
     # Admin messages
     "GetStatsRequest",
     "GetStatsResponse",
+    "GetUsageRequest",
+    "GetUsageResponse",
+    "InstanceUsage",
     "KVManagerStats",
     "AllocationManagerStats",
     # List allocations messages

--- a/maru_common/protocol.py
+++ b/maru_common/protocol.py
@@ -61,6 +61,7 @@ class MessageType(IntEnum):
     GET_STATS = 0xF0
     HEARTBEAT = 0xF1
     REPORT_STATS = 0xF2
+    GET_USAGE = 0xF3
     HANDSHAKE = 0xFE
     SHUTDOWN = 0xFF
 
@@ -448,6 +449,42 @@ class GetStatsResponse:
 
 
 @dataclass
+class GetUsageRequest:
+    """GET_USAGE (0xF3) - Request per-instance CXL usage."""
+
+    pass
+
+
+@dataclass
+class InstanceUsage:
+    """Per-instance (owner_instance_id) CXL memory usage.
+
+    ``allocated`` is the sum of region sizes the instance reserved;
+    ``used`` is the sum of live KV bytes stored in those regions.
+    Slack (allocated - used) is derived by the consumer.
+    """
+
+    instance_id: str
+    regions: int = 0
+    allocated: int = 0
+    used: int = 0
+
+
+@dataclass
+class GetUsageResponse:
+    """Response for GET_USAGE.
+
+    ``pool_total`` / ``pool_free`` are the shared device capacity reported
+    by the resource manager (summed across pools); any instance can draw
+    from the free space.
+    """
+
+    instances: list[InstanceUsage] = field(default_factory=list)
+    pool_total: int = 0
+    pool_free: int = 0
+
+
+@dataclass
 class HeartbeatRequest:
     """HEARTBEAT (0xF1) - Connection keepalive."""
 
@@ -536,6 +573,7 @@ MESSAGE_CLASSES = {
     MessageType.BATCH_UNPIN_KV: (BatchUnpinKVRequest, BatchUnpinKVResponse),
     # Admin
     MessageType.GET_STATS: (GetStatsRequest, GetStatsResponse),
+    MessageType.GET_USAGE: (GetUsageRequest, GetUsageResponse),
     MessageType.HEARTBEAT: (HeartbeatRequest, HeartbeatResponse),
     MessageType.REPORT_STATS: (ReportStatsRequest, ReportStatsResponse),
     MessageType.HANDSHAKE: (HandshakeRequest, HandshakeResponse),

--- a/maru_handler/rpc_client_base.py
+++ b/maru_handler/rpc_client_base.py
@@ -21,6 +21,8 @@ from maru_common import (
     BatchRegisterKVResponse,
     BatchUnpinKVResponse,
     GetStatsResponse,
+    GetUsageResponse,
+    InstanceUsage,
     KVManagerStats,
     ListAllocationsResponse,
     LookupKVResponse,
@@ -333,6 +335,29 @@ class RpcClientBase(abc.ABC):
                 active_clients=alloc_data.get("active_clients", 0),
             ),
             stats_manager=response.get("stats_manager", {}),
+        )
+
+    def get_usage(self) -> GetUsageResponse:
+        """Get per-instance CXL usage and shared pool totals.
+
+        Returns:
+            GetUsageResponse with one InstanceUsage per owner_instance_id
+            plus pool_total / pool_free (shared device capacity).
+        """
+        response = self._send_request(MessageType.GET_USAGE, {})
+        instances = [
+            InstanceUsage(
+                instance_id=i.get("instance_id", ""),
+                regions=i.get("regions", 0),
+                allocated=i.get("allocated", 0),
+                used=i.get("used", 0),
+            )
+            for i in response.get("instances", [])
+        ]
+        return GetUsageResponse(
+            instances=instances,
+            pool_total=response.get("pool_total", 0),
+            pool_free=response.get("pool_free", 0),
         )
 
     def report_stats(self, entries: list[dict]) -> None:

--- a/maru_handler/rpc_client_base.py
+++ b/maru_handler/rpc_client_base.py
@@ -343,8 +343,16 @@ class RpcClientBase(abc.ABC):
         Returns:
             GetUsageResponse with one InstanceUsage per owner_instance_id
             plus pool_total / pool_free (shared device capacity).
+
+        Raises:
+            ConnectionError: If the request fails (timeout / transport error)
+                or the server returns an error — including older servers that
+                predate GET_USAGE and cannot decode the message. This makes a
+                failed request distinguishable from a healthy-but-empty server.
         """
         response = self._send_request(MessageType.GET_USAGE, {})
+        if "error" in response:
+            raise ConnectionError(f"get_usage RPC failed: {response['error']}")
         instances = [
             InstanceUsage(
                 instance_id=i.get("instance_id", ""),

--- a/maru_server/allocation_manager.py
+++ b/maru_server/allocation_manager.py
@@ -184,6 +184,32 @@ class AllocationManager:
                 handles.append(info.handle)
             return handles
 
+    def region_owners(self) -> dict[int, str]:
+        """Map region_id -> owner_instance_id for all tracked allocations.
+
+        Includes deferred (owner_connected=False) regions, since they still
+        occupy CXL memory until their kv_ref_count drops to zero.
+        """
+        with self._lock:
+            return {
+                rid: info.owner_instance_id for rid, info in self._allocations.items()
+            }
+
+    def allocated_by_instance(self) -> dict[str, tuple[int, int]]:
+        """Per-owner allocation totals.
+
+        Returns:
+            Mapping of owner_instance_id -> (region_count, allocated_bytes).
+            Aggregated over all tracked allocations (connected or deferred).
+        """
+        with self._lock:
+            out: dict[str, list[int]] = {}
+            for info in self._allocations.values():
+                acc = out.setdefault(info.owner_instance_id, [0, 0])
+                acc[0] += 1
+                acc[1] += info.handle.length
+            return {iid: (acc[0], acc[1]) for iid, acc in out.items()}
+
     def get_stats(self) -> dict:
         """Get allocation statistics."""
         with self._lock:

--- a/maru_server/kv_manager.py
+++ b/maru_server/kv_manager.py
@@ -155,6 +155,19 @@ class KVManager:
                 "total_size": sum(e.kv_length for e in self._store.values()),
             }
 
+    def used_by_region(self) -> dict[int, int]:
+        """Sum of live KV bytes per region.
+
+        Returns:
+            Mapping of region_id -> total kv_length of entries stored there.
+            Used for per-instance usage accounting (joined with region owners).
+        """
+        with self._lock:
+            out: dict[int, int] = {}
+            for entry in self._store.values():
+                out[entry.region_id] = out.get(entry.region_id, 0) + entry.kv_length
+            return out
+
     # =========================================================================
     # Batch Operations
     # =========================================================================

--- a/maru_server/rpc_handler_mixin.py
+++ b/maru_server/rpc_handler_mixin.py
@@ -43,6 +43,7 @@ class RpcHandlerMixin:
                 MessageType.BATCH_UNPIN_KV.value: self._handle_batch_unpin_kv,
                 # Admin
                 MessageType.GET_STATS.value: self._handle_get_stats,
+                MessageType.GET_USAGE.value: self._handle_get_usage,
                 MessageType.HEARTBEAT.value: self._handle_heartbeat,
                 MessageType.REPORT_STATS.value: self._handle_report_stats,
                 MessageType.HANDSHAKE.value: self._handle_handshake,
@@ -240,6 +241,16 @@ class RpcHandlerMixin:
     def _handle_get_stats(self, _req: Any) -> dict:
         stats = self._server.get_stats()
         return stats
+
+    def _handle_get_usage(self, _req: Any) -> dict:
+        usage = self._server.get_usage()
+        logger.debug(
+            "[GET_USAGE] %d instances, pool_free=%d/%d",
+            len(usage.get("instances", [])),
+            usage.get("pool_free", 0),
+            usage.get("pool_total", 0),
+        )
+        return usage
 
     def _handle_report_stats(self, req: Any) -> dict:
         self._server.report_stats(req.entries)

--- a/maru_server/server.py
+++ b/maru_server/server.py
@@ -279,6 +279,56 @@ class MaruServer:
             "stats_manager": self._stats_manager.get_stats(),
         }
 
+    def get_usage(self) -> dict:
+        """Per-instance CXL usage plus shared pool totals.
+
+        For each owner_instance_id, reports the number of regions it owns,
+        the bytes it reserved (``allocated``), and the live KV bytes stored
+        in those regions (``used``). ``pool_total``/``pool_free`` are the
+        shared device capacity from the resource manager.
+        """
+        # Snapshot in-memory manager state atomically; the RM pool query is
+        # done outside the lock since it performs a network round-trip.
+        with self._lock:
+            alloc = self._allocation_manager.allocated_by_instance()
+            owners = self._allocation_manager.region_owners()
+            used_by_region = self._kv_manager.used_by_region()
+
+        used_by_instance: dict[str, int] = {}
+        for region_id, used in used_by_region.items():
+            owner = owners.get(region_id)
+            if owner is not None:
+                used_by_instance[owner] = used_by_instance.get(owner, 0) + used
+
+        instances = [
+            {
+                "instance_id": instance_id,
+                "regions": regions,
+                "allocated": allocated,
+                "used": used_by_instance.get(instance_id, 0),
+            }
+            for instance_id, (regions, allocated) in sorted(alloc.items())
+        ]
+
+        pool_total, pool_free = self._pool_totals()
+        return {
+            "instances": instances,
+            "pool_total": pool_total,
+            "pool_free": pool_free,
+        }
+
+    def _pool_totals(self) -> tuple[int, int]:
+        """Return (total_bytes, free_bytes) summed across resource manager pools."""
+        try:
+            pools = self._allocation_manager.pool_stats()
+        except Exception:
+            logger.warning("pool_stats failed during get_usage", exc_info=True)
+            return (0, 0)
+        return (
+            sum(p.total_size for p in pools),
+            sum(p.free_size for p in pools),
+        )
+
     def close(self) -> None:
         """Shutdown the server and release resources."""
         self._stats_manager.close()

--- a/tests/unit/test_allocation_manager.py
+++ b/tests/unit/test_allocation_manager.py
@@ -43,6 +43,43 @@ class TestAllocationManager:
         result = manager.get_handle(99999)
         assert result is None
 
+    def test_region_owners(self):
+        """region_owners maps each region_id to its owner instance."""
+        manager = AllocationManager()
+        h1 = manager.allocate("instance1", 1024)
+        h2 = manager.allocate("instance1", 2048)
+        h3 = manager.allocate("instance2", 4096)
+
+        owners = manager.region_owners()
+        assert owners == {
+            h1.region_id: "instance1",
+            h2.region_id: "instance1",
+            h3.region_id: "instance2",
+        }
+
+    def test_region_owners_empty(self):
+        """region_owners with no allocations is an empty mapping."""
+        manager = AllocationManager()
+        assert manager.region_owners() == {}
+
+    def test_allocated_by_instance(self):
+        """allocated_by_instance aggregates region count and bytes per owner."""
+        manager = AllocationManager()
+        manager.allocate("instance1", 1024)
+        manager.allocate("instance1", 2048)
+        manager.allocate("instance2", 4096)
+
+        by_instance = manager.allocated_by_instance()
+        assert by_instance == {
+            "instance1": (2, 1024 + 2048),
+            "instance2": (1, 4096),
+        }
+
+    def test_allocated_by_instance_empty(self):
+        """allocated_by_instance with no allocations is an empty mapping."""
+        manager = AllocationManager()
+        assert manager.allocated_by_instance() == {}
+
     def test_increment_kv_ref(self):
         """Test incrementing KV reference count."""
         manager = AllocationManager()

--- a/tests/unit/test_kv_manager.py
+++ b/tests/unit/test_kv_manager.py
@@ -39,6 +39,29 @@ class TestKVManager:
         assert entry.kv_offset == 1024
         assert entry.kv_length == 2048
 
+    def test_used_by_region_empty(self):
+        """used_by_region on an empty store returns an empty mapping."""
+        manager = KVManager()
+        assert manager.used_by_region() == {}
+
+    def test_used_by_region_sums_per_region(self):
+        """used_by_region sums kv_length grouped by region_id."""
+        manager = KVManager()
+        manager.register(key="a", region_id=1, kv_offset=0, kv_length=100)
+        manager.register(key="b", region_id=1, kv_offset=100, kv_length=200)
+        manager.register(key="c", region_id=2, kv_offset=0, kv_length=50)
+
+        assert manager.used_by_region() == {1: 300, 2: 50}
+
+    def test_used_by_region_reflects_delete(self):
+        """Deleting an entry removes its bytes from the region total."""
+        manager = KVManager()
+        manager.register(key="a", region_id=1, kv_offset=0, kv_length=100)
+        manager.register(key="b", region_id=1, kv_offset=100, kv_length=200)
+        manager.delete("a")
+
+        assert manager.used_by_region() == {1: 200}
+
     def test_lookup_nonexistent_key(self):
         """Test looking up a nonexistent key."""
         manager = KVManager()

--- a/tests/unit/test_maru_server.py
+++ b/tests/unit/test_maru_server.py
@@ -108,7 +108,9 @@ class TestGetUsage:
         h3 = server.request_alloc("instance2", 8192)
 
         server.register_kv(key="a", region_id=h1.region_id, kv_offset=0, kv_length=100)
-        server.register_kv(key="b", region_id=h1.region_id, kv_offset=100, kv_length=200)
+        server.register_kv(
+            key="b", region_id=h1.region_id, kv_offset=100, kv_length=200
+        )
         server.register_kv(key="c", region_id=h2.region_id, kv_offset=0, kv_length=50)
         server.register_kv(key="d", region_id=h3.region_id, kv_offset=0, kv_length=1000)
 

--- a/tests/unit/test_maru_server.py
+++ b/tests/unit/test_maru_server.py
@@ -87,6 +87,105 @@ class TestMaruBasic:
         assert stats["allocation_manager"]["num_allocations"] == 1
 
 
+class TestGetUsage:
+    """Test cases for MaruServer.get_usage() per-instance accounting."""
+
+    def test_get_usage_empty(self):
+        """No allocations -> empty instance list, zero pool totals (mock RM)."""
+        server = MaruServer()
+        usage = server.get_usage()
+        assert usage["instances"] == []
+        assert usage["pool_total"] == 0
+        assert usage["pool_free"] == 0
+
+    def test_get_usage_allocated_and_used(self):
+        """Per-instance allocated/used/regions aggregate correctly."""
+        server = MaruServer()
+        # instance1: two regions, partially filled
+        h1 = server.request_alloc("instance1", 4096)
+        h2 = server.request_alloc("instance1", 4096)
+        # instance2: one region
+        h3 = server.request_alloc("instance2", 8192)
+
+        server.register_kv(key="a", region_id=h1.region_id, kv_offset=0, kv_length=100)
+        server.register_kv(key="b", region_id=h1.region_id, kv_offset=100, kv_length=200)
+        server.register_kv(key="c", region_id=h2.region_id, kv_offset=0, kv_length=50)
+        server.register_kv(key="d", region_id=h3.region_id, kv_offset=0, kv_length=1000)
+
+        usage = server.get_usage()
+        by_id = {i["instance_id"]: i for i in usage["instances"]}
+
+        assert by_id["instance1"]["regions"] == 2
+        assert by_id["instance1"]["allocated"] == 4096 + 4096
+        assert by_id["instance1"]["used"] == 100 + 200 + 50  # joined across regions
+        assert by_id["instance2"]["regions"] == 1
+        assert by_id["instance2"]["allocated"] == 8192
+        assert by_id["instance2"]["used"] == 1000
+
+    def test_get_usage_instance_with_no_kv(self):
+        """An instance that allocated but stored nothing reports used=0."""
+        server = MaruServer()
+        server.request_alloc("idle", 4096)
+
+        usage = server.get_usage()
+        by_id = {i["instance_id"]: i for i in usage["instances"]}
+        assert by_id["idle"]["regions"] == 1
+        assert by_id["idle"]["used"] == 0
+
+    def test_get_usage_instances_sorted(self):
+        """Instances are returned sorted by instance_id."""
+        server = MaruServer()
+        server.request_alloc("zeta", 4096)
+        server.request_alloc("alpha", 4096)
+
+        usage = server.get_usage()
+        ids = [i["instance_id"] for i in usage["instances"]]
+        assert ids == sorted(ids)
+
+    def test_get_usage_pool_totals(self, monkeypatch):
+        """pool_total / pool_free are summed from resource manager pools."""
+        from maru_shm.types import DaxType, MaruPoolInfo
+
+        server = MaruServer()
+        monkeypatch.setattr(
+            server._allocation_manager,
+            "pool_stats",
+            lambda: [
+                MaruPoolInfo(
+                    dax_path="/dev/dax0.0",
+                    dax_type=DaxType.DEV_DAX,
+                    total_size=100,
+                    free_size=60,
+                    align_bytes=2 << 20,
+                ),
+                MaruPoolInfo(
+                    dax_path="/dev/dax0.1",
+                    dax_type=DaxType.DEV_DAX,
+                    total_size=200,
+                    free_size=150,
+                    align_bytes=2 << 20,
+                ),
+            ],
+        )
+
+        usage = server.get_usage()
+        assert usage["pool_total"] == 300
+        assert usage["pool_free"] == 210
+
+    def test_get_usage_pool_stats_failure_is_tolerated(self, monkeypatch):
+        """If the RM pool query fails, pool totals fall back to 0."""
+        server = MaruServer()
+
+        def _boom():
+            raise RuntimeError("rm down")
+
+        monkeypatch.setattr(server._allocation_manager, "pool_stats", _boom)
+
+        usage = server.get_usage()
+        assert usage["pool_total"] == 0
+        assert usage["pool_free"] == 0
+
+
 class TestClientDisconnected:
     """Test cases for MaruServer.client_disconnected()."""
 

--- a/tests/unit/test_maru_server.py
+++ b/tests/unit/test_maru_server.py
@@ -185,6 +185,33 @@ class TestGetUsage:
         assert usage["pool_total"] == 0
         assert usage["pool_free"] == 0
 
+    def test_get_usage_includes_deferred_owner(self):
+        """A disconnected owner whose region is kept alive by KV refs (deferred
+        free) still appears in usage with its held bytes."""
+        server = MaruServer()
+        handle = server.request_alloc("gone", 4096)
+        server.register_kv(
+            key="k", region_id=handle.region_id, kv_offset=0, kv_length=128
+        )
+        # Owner disconnects, but the KV ref keeps the region from being freed.
+        server.client_disconnected("gone")
+
+        usage = server.get_usage()
+        by_id = {i["instance_id"]: i for i in usage["instances"]}
+        assert "gone" in by_id
+        assert by_id["gone"]["regions"] == 1
+        assert by_id["gone"]["used"] == 128
+
+    def test_get_usage_orphan_kv_region_ignored(self):
+        """A KV entry referencing a region with no allocation entry (orphan) is
+        dropped from per-instance accounting rather than crashing."""
+        server = MaruServer()
+        # Register against a region that was never allocated on this server.
+        server.register_kv(key="orphan", region_id=99999, kv_offset=0, kv_length=500)
+
+        usage = server.get_usage()
+        assert usage["instances"] == []  # no owning instance -> nothing attributed
+
 
 class TestClientDisconnected:
     """Test cases for MaruServer.client_disconnected()."""

--- a/tests/unit/test_rpc_server.py
+++ b/tests/unit/test_rpc_server.py
@@ -63,6 +63,29 @@ class TestRpcServerHandlerDispatch:
         assert "error" in response
         assert response["error"] == "Allocation failed"
 
+    def test_handle_get_usage(self, server_cls):
+        """_handle_get_usage returns per-instance usage and pool totals."""
+        server = MaruServer()
+        if server_cls is RpcServer:
+            rpc = RpcServer(server, host="127.0.0.1", port=5555)
+        else:
+            rpc = RpcAsyncServer(server, host="127.0.0.1", port=5555, num_workers=2)
+
+        handle = server.request_alloc("instance1", 4096)
+        server.register_kv(
+            key="k", region_id=handle.region_id, kv_offset=0, kv_length=128
+        )
+
+        response = rpc._handle_get_usage(MockRequest())
+
+        assert "instances" in response
+        assert "pool_total" in response
+        assert "pool_free" in response
+        inst = {i["instance_id"]: i for i in response["instances"]}
+        assert inst["instance1"]["regions"] == 1
+        assert inst["instance1"]["allocated"] == 4096
+        assert inst["instance1"]["used"] == 128
+
 
 class TestRpcServerStartLoop:
     """Test RpcServer.start() main loop error handling for 100% coverage."""

--- a/tests/unit/test_usage_monitor.py
+++ b/tests/unit/test_usage_monitor.py
@@ -5,6 +5,8 @@
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 from maru_common import GetUsageResponse, InstanceUsage, MessageType
 from maru_handler.rpc_client_base import RpcClientBase
 
@@ -54,6 +56,13 @@ class TestGetUsageClientParse:
         assert resp.pool_total == 0
         assert resp.pool_free == 0
 
+    def test_raises_on_error_response(self):
+        """An error dict (timeout / transport / old server) must raise, not
+        silently render as an empty/healthy server."""
+        client = _FakeClient({"error": "timeout", "success": False})
+        with pytest.raises(ConnectionError):
+            client.get_usage()
+
 
 # tools/ is not an installed package — load the tool module by file path.
 _TOOL_PATH = Path(__file__).resolve().parents[2] / "tools" / "usage_monitor.py"
@@ -91,6 +100,12 @@ class TestUsageMonitorRendering:
         assert usage_monitor._fmt_size(1024) == "1.0K"
         assert usage_monitor._fmt_size(1024**3) == "1.0G"
         assert usage_monitor._fmt_size(1024**4) == "1.0T"
+
+    def test_fmt_size_negative(self):
+        # Negative slack (broken upstream invariant) renders with a sign and
+        # correct magnitude unit, not a bogus fractional-K value.
+        assert usage_monitor._fmt_size(-(1024**3)) == "-1.0G"
+        assert usage_monitor._fmt_size(-1024) == "-1.0K"
 
     def test_render_table_contains_rows(self):
         out = usage_monitor.render_table(_sample_usage(), "2026-06-15T00:00:00")

--- a/tests/unit/test_usage_monitor.py
+++ b/tests/unit/test_usage_monitor.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 XCENA Inc.
+"""Tests for the GET_USAGE client parser and the usage_monitor tool."""
+
+import importlib.util
+from pathlib import Path
+
+from maru_common import GetUsageResponse, InstanceUsage, MessageType
+from maru_handler.rpc_client_base import RpcClientBase
+
+
+class _FakeClient(RpcClientBase):
+    """RpcClientBase with a canned _send_request, for parser testing."""
+
+    def __init__(self, response: dict):
+        self._response = response
+        self.last_msg_type = None
+
+    def _send_request(self, msg_type, data):
+        self.last_msg_type = msg_type
+        return self._response
+
+
+class TestGetUsageClientParse:
+    """RpcClientBase.get_usage() wire-dict -> dataclass parsing."""
+
+    def test_parses_instances_and_pool(self):
+        client = _FakeClient(
+            {
+                "instances": [
+                    {"instance_id": "vllm-0", "regions": 3, "allocated": 12, "used": 9},
+                    {"instance_id": "vllm-1", "regions": 2, "allocated": 8, "used": 7},
+                ],
+                "pool_total": 100,
+                "pool_free": 60,
+            }
+        )
+        resp = client.get_usage()
+
+        assert client.last_msg_type == MessageType.GET_USAGE
+        assert isinstance(resp, GetUsageResponse)
+        assert resp.pool_total == 100
+        assert resp.pool_free == 60
+        assert len(resp.instances) == 2
+        first = resp.instances[0]
+        assert first.instance_id == "vllm-0"
+        assert first.regions == 3
+        assert first.allocated == 12
+        assert first.used == 9
+
+    def test_parses_empty_response(self):
+        resp = _FakeClient({}).get_usage()
+        assert resp.instances == []
+        assert resp.pool_total == 0
+        assert resp.pool_free == 0
+
+
+# tools/ is not an installed package — load the tool module by file path.
+_TOOL_PATH = Path(__file__).resolve().parents[2] / "tools" / "usage_monitor.py"
+_spec = importlib.util.spec_from_file_location("usage_monitor", _TOOL_PATH)
+usage_monitor = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(usage_monitor)
+
+
+def _sample_usage() -> GetUsageResponse:
+    return GetUsageResponse(
+        instances=[
+            InstanceUsage(
+                instance_id="vllm-0",
+                regions=3,
+                allocated=12 * 1024**3,
+                used=9 * 1024**3,
+            ),
+            InstanceUsage(
+                instance_id="vllm-1",
+                regions=2,
+                allocated=8 * 1024**3,
+                used=7 * 1024**3,
+            ),
+        ],
+        pool_total=242 * 1024**3,
+        pool_free=229 * 1024**3,
+    )
+
+
+class TestUsageMonitorRendering:
+    """usage_monitor.py formatting helpers."""
+
+    def test_fmt_size(self):
+        assert usage_monitor._fmt_size(0) == "0B"
+        assert usage_monitor._fmt_size(1024) == "1.0K"
+        assert usage_monitor._fmt_size(1024**3) == "1.0G"
+        assert usage_monitor._fmt_size(1024**4) == "1.0T"
+
+    def test_render_table_contains_rows(self):
+        out = usage_monitor.render_table(_sample_usage(), "2026-06-15T00:00:00")
+        assert "vllm-0" in out
+        assert "vllm-1" in out
+        assert "slack" in out
+        assert "TOTAL" in out
+        assert "Pool (shared)" in out
+
+    def test_render_table_empty(self):
+        out = usage_monitor.render_table(GetUsageResponse(), "2026-06-15T00:00:00")
+        assert "no active instances" in out
+
+    def test_csv_rows(self, capsys):
+        usage_monitor.print_csv_header()
+        usage_monitor.print_csv_rows(_sample_usage(), "2026-06-15T00:00:00")
+        lines = capsys.readouterr().out.strip().splitlines()
+
+        assert lines[0].startswith("timestamp,instance_id,regions")
+        row0 = lines[1].split(",")
+        assert row0[1] == "vllm-0"
+        # slack column == allocated - used
+        assert int(row0[5]) == int(row0[3]) - int(row0[4])

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,5 +1,16 @@
 # Tools
 
+Three monitors, each at a different layer — they complement rather than
+overlap (the only shared figure is pool free):
+
+| Tool | Layer | Source | Answers |
+|---|---|---|---|
+| `pool_monitor.py` | physical device/pool | resource manager (`:9850`) | "how full is each DAX device?" |
+| `usage_monitor.py` | logical per-instance | MaruServer (`:5555`) | "who is holding what, and how much is left?" |
+| `stats_monitor.py` | operations/performance | MaruServer (`:5555`) | "who is doing how many ops, how fast?" |
+
+(`maru_rm_tool.py` is a device-header utility, not a monitor.)
+
 ## pool_monitor.py
 
 Real-time maru memory pool usage monitor.
@@ -34,6 +45,60 @@ timestamp,pool_id,dax_type,total_bytes,free_bytes,used_bytes,usage_pct
 2026-03-11T14:30:05,0,DEV_DAX,260717199360,245861867520,14855331840,5.70
 2026-03-11T14:30:05,1,DEV_DAX,3578455826432,14855331840,3563600494592,99.58
 ```
+
+## usage_monitor.py
+
+Per-instance CXL usage monitor. Shows, for each client instance
+(`owner_instance_id`), how much CXL memory it reserved (**allocated**) versus
+how much is live KV data (**used**), the difference (**slack**), and the shared
+pool free space. Queries MaruServer over the `GET_USAGE` RPC — no `MARU_STAT`
+required.
+
+```bash
+python -m tools.usage_monitor                  # one-shot snapshot
+python -m tools.usage_monitor -w 1             # refresh every 1s
+python -m tools.usage_monitor -w 1 -c 30       # 30 iterations then exit
+python -m tools.usage_monitor --csv            # CSV for post-processing
+python -m tools.usage_monitor --host 10.0.0.1 -p 5556
+```
+
+Options:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--host` | `127.0.0.1` | MaruServer host |
+| `-p`, `--port` | `5555` | MaruServer port |
+| `-w`, `--watch` | `0` | Refresh interval in seconds (0 = one-shot) |
+| `-c`, `--count` | `0` | Number of iterations (0 = unlimited) |
+| `--csv` | off | CSV output for post-processing |
+| `--scroll` | off | Scrolling log instead of top-style refresh |
+
+### Example Output
+
+```
+  Maru Usage Monitor  —  2026-06-15T14:30:05  (Ctrl+C to quit)
+
+  owner_instance_id                       regions  allocated       used      slack
+  --------------------------------------  -------  ---------  ---------  ---------
+  vllm-0                                        3      12.0G       9.4G       2.6G
+  vllm-1                                        2       8.0G       7.9G       0.1G
+  --------------------------------------  -------  ---------  ---------  ---------
+  TOTAL                                         5      20.0G      17.3G       2.7G
+
+  Pool (shared): 229.0G free / 242.8G total  [##----------------------------] 5.7%
+```
+
+**CSV mode** (`--csv`):
+
+```
+timestamp,instance_id,regions,allocated_bytes,used_bytes,slack_bytes,pool_total_bytes,pool_free_bytes
+2026-06-15T14:30:05,vllm-0,3,12884901888,10093173964,2791727924,260717199360,245861867520
+```
+
+> **Note:** `instance_id` identifies one `MaruBackend` = one process/worker
+> (TP/DP runs one per worker), and the default is a random UUID per process.
+> Set `maru_instance_id` in the integration's `extra_config` for stable,
+> readable rows.
 
 ## stats_monitor.py
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -139,6 +139,49 @@ Options:
 | `-p`, `--port` | `5555` | MaruServer port |
 | `-i`, `--interval` | `1.0` | Refresh interval in seconds |
 
+### Example Output
+
+Interactive curses dashboard (the selected row, `▶`, drives the detail panel):
+
+```
+  Maru Stats Monitor  14:30:05    KV:1820 (4.2G)  Alloc:6 (24.0G)  Inst:2
+
+  ▐ ALL ▌   Instance 0    Instance 1
+
+  operation             │   count│  delta│   avg_us│   min_us│   max_us│                  activity
+  ──────────────────────┼────────┼───────┼─────────┼─────────┼─────────┼──────────────────────────
+▶ store                 │    8124│    +37│     45.2│     12.1│    230.0│         ▂▃▅▇▆▅▃▂▃▄▅▆▇▅▃▂▃▄▅
+  retrieve              │   15330│    +71│     18.7│      5.0│     92.4│         ▁▂▄▆▇▆▄▂▁▂▃▅▇▆▄▂▁▂▃
+  exists                │   20106│   +112│      6.3│      2.1│     40.0│         ▃▄▅▆▇▇▆▅▄▃▄▅▆▇▆▅▄▃▄▅
+  pin                   │   15330│    +71│      7.1│      2.4│     38.9│         ▁▂▃▄▅▆▇▆▅▄▃▂▁▂▃▄▅▆▇▆
+  alloc                 │     820│     +4│     12.5│      4.0│     88.0│         ▁▁▂▂▃▃▂▂▁▁▂▂▃▃▂▂▁▁▂▂
+  delete                │       0│       │      0.0│      0.0│      0.0│
+  batch_retrieve        │    1240│    +6│     210.4│     85.0│    640.0│         ▂▄▆▇▅▃▂▄▆▇▅▃▂▄▆▇▅▃▂▄
+
+  ╭─ store ──────────────────────────────────────────────────────────────────────────────────╮
+  │ count: 8124    bytes: 3.8G                                                                  │
+  │                                                                                            │
+  │ latency (us):  avg=45.2  min=12.1  max=230.0                                                │
+  │ throughput:    812.4 MB/s                                                                   │
+  ╰────────────────────────────────────────────────────────────────────────────────────────────╯
+  ╭─ latency (us) ───────────────────────────────────────────────────────────────────────────╮
+  │                                                                                            │
+  │  230.0 ┤            ▴         ▴                                                             │
+  │        │      ▴   ▴     ▴   ▴                                                               │
+  │  115.0 ┤   •    •    •     •      •                                                         │
+  │        │ •    •   •    •      •                                                             │
+  │        │▾   ▾    ▾    ▾    ▾                                                                 │
+  │    0.0 ┤  ▾    ▾                                                                            │
+  │        └──────────────────────────────────────                                            │
+  │        ▴=max  •=avg  ▾=min                                                                  │
+  ╰────────────────────────────────────────────────────────────────────────────────────────────╯
+
+  q:quit  ↑↓:select  ←→:instance
+```
+
+(The `delta` column shows the per-interval count; rows with no activity in the
+window stay blank. The `activity` sparkline is the last 25 ticks.)
+
 ### Key bindings
 
 | Key | Action |

--- a/tools/README.md
+++ b/tools/README.md
@@ -99,6 +99,9 @@ timestamp,instance_id,regions,allocated_bytes,used_bytes,slack_bytes,pool_total_
 > (TP/DP runs one per worker), and the default is a random UUID per process.
 > Set `maru_instance_id` in the integration's `extra_config` for stable,
 > readable rows.
+>
+> Requires a MaruServer that supports the `GET_USAGE` RPC. Against an older
+> server the tool reports a connection error rather than an empty table.
 
 ## stats_monitor.py
 

--- a/tools/usage_monitor.py
+++ b/tools/usage_monitor.py
@@ -69,9 +69,7 @@ def render_table(usage: GetUsageResponse, ts: str) -> str:
             f"  {'owner_instance_id':<38}  {'regions':>7}  "
             f"{'allocated':>9}  {'used':>9}  {'slack':>9}"
         )
-        lines.append(
-            f"  {'-' * 38}  {'-' * 7}  {'-' * 9}  {'-' * 9}  {'-' * 9}"
-        )
+        lines.append(f"  {'-' * 38}  {'-' * 7}  {'-' * 9}  {'-' * 9}  {'-' * 9}")
         for inst in instances:
             slack = inst.allocated - inst.used
             lines.append(
@@ -81,9 +79,7 @@ def render_table(usage: GetUsageResponse, ts: str) -> str:
             )
         total_alloc = sum(i.allocated for i in instances)
         total_used = sum(i.used for i in instances)
-        lines.append(
-            f"  {'-' * 38}  {'-' * 7}  {'-' * 9}  {'-' * 9}  {'-' * 9}"
-        )
+        lines.append(f"  {'-' * 38}  {'-' * 7}  {'-' * 9}  {'-' * 9}  {'-' * 9}")
         lines.append(
             f"  {'TOTAL':<38}  {len(instances):>7}  "
             f"{_fmt_size(total_alloc):>9}  {_fmt_size(total_used):>9}  "
@@ -167,7 +163,9 @@ def main() -> None:
     try:
         client.connect()
     except Exception as e:
-        print(f"Error: cannot connect to MaruServer at {server_url}: {e}", file=sys.stderr)
+        print(
+            f"Error: cannot connect to MaruServer at {server_url}: {e}", file=sys.stderr
+        )
         sys.exit(1)
 
     try:

--- a/tools/usage_monitor.py
+++ b/tools/usage_monitor.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Maru per-instance CXL usage monitor.
+
+Shows, per client instance (owner_instance_id), how much CXL memory it
+reserved (allocated) versus how much is actually live KV data (used),
+plus the shared pool free space. Queries MaruServer over RPC.
+
+Usage:
+    python -m tools.usage_monitor                  # one-shot snapshot
+    python -m tools.usage_monitor -w 1             # refresh every 1s
+    python -m tools.usage_monitor -w 1 -c 30       # 30 iterations then exit
+    python -m tools.usage_monitor --csv            # CSV for post-processing
+    python -m tools.usage_monitor --host H -p 5555 # target a MaruServer
+
+Note:
+    ``instance_id`` identifies one MaruBackend = one process/worker, and the
+    default is a random UUID per process. Set ``maru_instance_id`` in the
+    integration's extra_config for stable, readable rows.
+"""
+
+import argparse
+import logging
+import sys
+import time
+from datetime import datetime
+
+from maru_common import GetUsageResponse
+from maru_handler.rpc_client import RpcClient
+
+
+def _fmt_size(nbytes: int) -> str:
+    if nbytes == 0:
+        return "0B"
+    if nbytes >= 1024**4:
+        return f"{nbytes / 1024**4:.1f}T"
+    if nbytes >= 1024**3:
+        return f"{nbytes / 1024**3:.1f}G"
+    if nbytes >= 1024**2:
+        return f"{nbytes / 1024**2:.1f}M"
+    return f"{nbytes / 1024:.1f}K"
+
+
+def _usage_bar(used: int, total: int, width: int = 30) -> str:
+    if total == 0:
+        return "[" + "?" * width + "]"
+    ratio = used / total
+    filled = int(ratio * width)
+    return "[" + "#" * filled + "-" * (width - filled) + f"] {ratio * 100:.1f}%"
+
+
+def _clear_screen() -> None:
+    sys.stdout.write("\033[2J\033[H")
+    sys.stdout.flush()
+
+
+def render_table(usage: GetUsageResponse, ts: str) -> str:
+    """Render the per-instance usage table to a string."""
+    lines = []
+    lines.append(f"  Maru Usage Monitor  —  {ts}  (Ctrl+C to quit)")
+    lines.append("")
+
+    instances = sorted(usage.instances, key=lambda i: i.instance_id)
+    if not instances:
+        lines.append("  (no active instances)")
+    else:
+        lines.append(
+            f"  {'owner_instance_id':<38}  {'regions':>7}  "
+            f"{'allocated':>9}  {'used':>9}  {'slack':>9}"
+        )
+        lines.append(
+            f"  {'-' * 38}  {'-' * 7}  {'-' * 9}  {'-' * 9}  {'-' * 9}"
+        )
+        for inst in instances:
+            slack = inst.allocated - inst.used
+            lines.append(
+                f"  {inst.instance_id:<38}  {inst.regions:>7}  "
+                f"{_fmt_size(inst.allocated):>9}  {_fmt_size(inst.used):>9}  "
+                f"{_fmt_size(slack):>9}"
+            )
+        total_alloc = sum(i.allocated for i in instances)
+        total_used = sum(i.used for i in instances)
+        lines.append(
+            f"  {'-' * 38}  {'-' * 7}  {'-' * 9}  {'-' * 9}  {'-' * 9}"
+        )
+        lines.append(
+            f"  {'TOTAL':<38}  {len(instances):>7}  "
+            f"{_fmt_size(total_alloc):>9}  {_fmt_size(total_used):>9}  "
+            f"{_fmt_size(total_alloc - total_used):>9}"
+        )
+
+    lines.append("")
+    pool_used = usage.pool_total - usage.pool_free
+    lines.append(
+        f"  Pool (shared): {_fmt_size(usage.pool_free)} free / "
+        f"{_fmt_size(usage.pool_total)} total  "
+        f"{_usage_bar(pool_used, usage.pool_total)}"
+    )
+    return "\n".join(lines)
+
+
+def print_csv_header() -> None:
+    print(
+        "timestamp,instance_id,regions,allocated_bytes,used_bytes,"
+        "slack_bytes,pool_total_bytes,pool_free_bytes"
+    )
+
+
+def print_csv_rows(usage: GetUsageResponse, ts: str) -> None:
+    for inst in sorted(usage.instances, key=lambda i: i.instance_id):
+        slack = inst.allocated - inst.used
+        print(
+            f"{ts},{inst.instance_id},{inst.regions},{inst.allocated},"
+            f"{inst.used},{slack},{usage.pool_total},{usage.pool_free}"
+        )
+
+
+def snapshot(client: RpcClient) -> GetUsageResponse:
+    return client.get_usage()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Maru per-instance CXL usage monitor")
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="MaruServer host (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        type=int,
+        default=5555,
+        help="MaruServer port (default: 5555)",
+    )
+    parser.add_argument(
+        "-w",
+        "--watch",
+        type=float,
+        default=0,
+        help="Refresh interval in seconds (0 = one-shot)",
+    )
+    parser.add_argument(
+        "-c",
+        "--count",
+        type=int,
+        default=0,
+        help="Number of iterations (0 = unlimited)",
+    )
+    parser.add_argument("--csv", action="store_true", help="Output in CSV format")
+    parser.add_argument(
+        "--scroll",
+        action="store_true",
+        help="Scrolling log instead of top-style refresh",
+    )
+    args = parser.parse_args()
+
+    # Quiet the client libraries so they don't clutter the table.
+    logging.getLogger("maru_handler").setLevel(logging.WARNING)
+    logging.getLogger("maru_common").setLevel(logging.WARNING)
+
+    server_url = f"tcp://{args.host}:{args.port}"
+    client = RpcClient(server_url=server_url)
+    try:
+        client.connect()
+    except Exception as e:
+        print(f"Error: cannot connect to MaruServer at {server_url}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        if args.watch <= 0:
+            usage = snapshot(client)
+            ts = datetime.now().isoformat(timespec="seconds")
+            if args.csv:
+                print_csv_header()
+                print_csv_rows(usage, ts)
+            else:
+                print(render_table(usage, ts))
+            return
+
+        iteration = 0
+        if args.csv:
+            print_csv_header()
+
+        while True:
+            ts = datetime.now().isoformat(timespec="seconds")
+            try:
+                usage = snapshot(client)
+            except Exception as e:
+                print(f"  [error] {e}", file=sys.stderr)
+                time.sleep(args.watch)
+                continue
+
+            if args.csv:
+                print_csv_rows(usage, ts)
+                sys.stdout.flush()
+            else:
+                output = render_table(usage, ts)
+                if args.scroll:
+                    print(output)
+                    print()
+                else:
+                    _clear_screen()
+                    print(output)
+                sys.stdout.flush()
+
+            iteration += 1
+            if args.count > 0 and iteration >= args.count:
+                break
+            time.sleep(args.watch)
+    except KeyboardInterrupt:
+        print("\nStopped.")
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/usage_monitor.py
+++ b/tools/usage_monitor.py
@@ -29,6 +29,8 @@ from maru_handler.rpc_client import RpcClient
 
 
 def _fmt_size(nbytes: int) -> str:
+    if nbytes < 0:
+        return "-" + _fmt_size(-nbytes)
     if nbytes == 0:
         return "0B"
     if nbytes >= 1024**4:
@@ -151,7 +153,8 @@ def main() -> None:
     parser.add_argument(
         "--scroll",
         action="store_true",
-        help="Scrolling log instead of top-style refresh",
+        help="Scrolling log instead of top-style refresh (table mode only; "
+        "ignored with --csv)",
     )
     args = parser.parse_args()
 
@@ -169,7 +172,11 @@ def main() -> None:
 
     try:
         if args.watch <= 0:
-            usage = snapshot(client)
+            try:
+                usage = snapshot(client)
+            except Exception as e:
+                print(f"Error: {e}", file=sys.stderr)
+                sys.exit(1)
             ts = datetime.now().isoformat(timespec="seconds")
             if args.csv:
                 print_csv_header()


### PR DESCRIPTION
## 🤔 Background & Motivation (Why)

There is no way to see **how much CXL memory each client is holding, or how much is left**. The existing monitors answer different questions:

| Tool | Layer | Answers |
|---|---|---|
| `pool_monitor.py` | physical device | "how full is each DAX device?" |
| `stats_monitor.py` | operations | "who is doing how many ops, how fast?" |
| **(missing)** | **logical / per-instance** | **"who is holding what, and how much is left?"** |

The data already exists server-side (`AllocationManager` owner/region sizes, `KVManager` per-region bytes) but is only exposed as global aggregates. This PR surfaces it per instance.

## 🏗️ Design Changes

| Type | Change |
|---|---|
| **API (new)** | `GET_USAGE` RPC (`0xF3`) + `GetUsageRequest` / `InstanceUsage` / `GetUsageResponse`. Empty request; `PROTOCOL_VERSION` unchanged. |
| **Behavioral** | `RpcClientBase.get_usage()` raises `ConnectionError` on an error response — a transport failure (or an old server that can't decode `GET_USAGE`) is no longer indistinguishable from a healthy-but-empty server. |
| **Scope** | Read-only endpoint. The alloc / store / retrieve data path is untouched. |

How a row is computed (server-side join, all data already tracked):

```mermaid
flowchart LR
    A["AllocationManager<br/>region → owner, size"] -->|allocated_by_instance| J
    A -->|region_owners| J
    K["KVManager<br/>region → Σ kv_length"] -->|used_by_region| J
    J["get_usage(): join by region → owner"] --> R["per-instance: regions, allocated, used"]
    P["resource manager<br/>pool_stats()"] --> O["pool_total / pool_free (shared)"]
```

`allocated` = Σ region sizes per owner · `used` = Σ KV bytes in those regions · `slack` = allocated − used · `pool free` = shared device capacity.

## 📝 Implementation Details

**Files**

| File | Change |
|---|---|
| `maru_common/protocol.py` | `GET_USAGE` type + 3 dataclasses, registered in `MESSAGE_CLASSES` |
| `maru_server/kv_manager.py` | `used_by_region()` → `region_id → Σ kv_length` |
| `maru_server/allocation_manager.py` | `region_owners()`, `allocated_by_instance()` |
| `maru_server/server.py` | `get_usage()` joins the above; in-memory snapshot under `self._lock`, RM `pool_stats()` **outside** the lock with a `(0,0)` fallback |
| `maru_server/rpc_handler_mixin.py` | one handler → serves both sync `RpcServer` and async `RpcAsyncServer` |
| `maru_handler/rpc_client_base.py` | `get_usage()` (inherited by sync + async clients); raises on error |
| `tools/usage_monitor.py` | live table / CSV / `-w` watch CLI |
| `tools/README.md` | 3-monitor layer matrix + output examples for all three tools |

**Edge cases handled**
- Deferred owner (disconnected but KV-pinned) → still reported with its held bytes.
- Orphan KV (region with no allocation) → dropped, not crashed.
- RM pool query fails → totals fall back to `0`, endpoint still returns.

**Reviewer note** — `instance_id` = one `MaruBackend` = one process/worker (TP/DP runs one per worker), default a random UUID; set `maru_instance_id` for stable rows. A `group`/`tenant` roll-up (true "per-user") is intentionally left as follow-up (see #55). Pool free is shared capacity (no per-instance quotas).

### Usage

```bash
python -m tools.usage_monitor                  # one-shot snapshot
python -m tools.usage_monitor -w 1             # live, refresh every 1s
python -m tools.usage_monitor -w 1 -c 30       # 30 refreshes then exit
python -m tools.usage_monitor --csv            # CSV for post-processing
python -m tools.usage_monitor --host H -p 5556 # target a specific MaruServer
```

### Output

Table (default):

```
  owner_instance_id        regions  allocated   used     slack
  -----------------------  -------  ----------  -------  -------
  vllm-0                         3      12.0G    9.4G     2.6G
  vllm-1                         2       8.0G    7.9G     0.1G
  -----------------------  -------  ----------  -------  -------
  TOTAL                          5      20.0G    17.3G    2.7G

  Pool (shared): 229.0G free / 242.8G total  [##----------------------------] 5.7%
```

CSV (`--csv`):

```
timestamp,instance_id,regions,allocated_bytes,used_bytes,slack_bytes,pool_total_bytes,pool_free_bytes
2026-06-15T14:30:05,vllm-0,3,12884901888,10093173964,2791727924,260717199360,245861867520
```

## ✅ Tests
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] No tests needed (reason:                )

Covers manager aggregation, the `get_usage` join (incl. deferred-owner and orphan-KV paths), pool-totals success + failure fallback, sync **and** async handler dispatch, client parser (populated / empty / error), and tool render + CSV. `ruff check` and `ruff format --check` clean.

## 🔗 Related Issues (optional)
Closes #55

## 📦 Release Note (for auto-generation / write in English)
### NEW
- Maru: Added per-instance CXL usage monitoring — a `GET_USAGE` RPC and `tools/usage_monitor.py` reporting allocated / used / slack per client instance plus shared pool free.
### CHANGED
-
### FIXED
-
### IMPORTANT NOTES
-
