### PR TITLE
fix: store all chunked-prefill steps in MaruKVConnector, not just the first

### DIFF
--- a/maru_vllm/connector.py
+++ b/maru_vllm/connector.py
@@ -528,22 +528,22 @@ class MaruSchedulerConnector:
                 if stored_chunks < num_full_chunks:
                     self._requests_need_store[new_req.req_id] = token_ids
 
-        # Handle resumed requests (chunked prefill continuations).
+        # Cached requests: chunked-prefill continuations and resumed loads.
+        # Do NOT gate the store on ``resumed`` — chunked-prefill requests
+        # reappear here every step un-resumed, so gating stored only the first
+        # chunk. See design note 20260624_maru-vllm-direct-chunked-prefill-store-bug.
         cached_reqs = scheduler_output.scheduled_cached_reqs
         for i, req_id in enumerate(cached_reqs.req_ids):
-            resumed = req_id in cached_reqs.resumed_req_ids
-            if not resumed:
-                continue
-
             num_new = scheduler_output.num_scheduled_tokens.get(req_id, 0)
             new_block_ids = cached_reqs.new_block_ids[i]
             if new_block_ids is None:
                 continue
+            num_computed = cached_reqs.num_computed_tokens[i]
+            resumed = req_id in cached_reqs.resumed_req_ids
 
-            if req_id in self._requests_need_load:
-                # Still needs load from maru
+            if resumed and req_id in self._requests_need_load:
+                # Resumed from preemption and still needs its KV loaded.
                 request, num_chunks = self._requests_need_load[req_id]
-                num_computed = cached_reqs.num_computed_tokens[i]
                 total_tokens = num_computed + num_new
                 token_ids = list(request.all_token_ids[:total_tokens])
 
@@ -557,9 +557,9 @@ class MaruSchedulerConnector:
                     )
                 )
             elif req_id in self._requests_need_store:
-                # Chunked prefill continuation — store newly computed chunks
+                # Chunked-prefill continuation (normal progression OR resumed):
+                # store the chunks computed in this step.
                 token_ids = self._requests_need_store[req_id]
-                num_computed = cached_reqs.num_computed_tokens[i]
                 meta.requests.append(
                     MaruReqMeta(
                         req_id=req_id,
@@ -570,8 +570,7 @@ class MaruSchedulerConnector:
                         num_computed_tokens=num_computed,
                     )
                 )
-                # Check if all chunks are now covered
-                num_computed = cached_reqs.num_computed_tokens[i]
+                # Drop tracking once all full chunks have been stored.
                 total_scheduled = num_computed + num_new
                 num_full_chunks = len(token_ids) // self._kv_chunk_tokens
                 if total_scheduled // self._kv_chunk_tokens >= num_full_chunks:


### PR DESCRIPTION
## 🤔 Background & Motivation (Why)

`MaruKVConnector` (the direct vLLM↔Maru KV connector, no LMCache) silently failed to reuse KV for prompts longer than a single chunked-prefill step. It did **not** crash — requests completed and TTFT-based heuristics even reported a "cache hit" — but the externally-cached prefix actually reused on a warm request collapsed for long prompts.

**Symptom.** Store a long prompt, then retrieve the same prompt: the warm request re-ran almost the entire prefill. Measured with a fresh-prompt `/metrics` counter diff (`external_prefix_cache_{queries,hits}_total`, Qwen2.5-0.5B, `max_num_batched_tokens=8192`), the warm hit rate was *exactly* `max_num_batched_tokens / prompt_len`:

| prompt tokens | chunked? | warm hit rate | `8192 / ntok` |
|---:|:--:|---:|---:|
| 2000–7000 | no (1 step) | 90–99% | (full) |
| 9000 | yes | **91.0%** | 91.0% |
| 12000 | yes | **68.3%** | 68.3% |
| 18000 | yes | **45.5%** | 45.5% |
| 64000 | yes | ~13% | 12.8% |

The hit rate equals `8192 / prompt_len`: only the first chunked-prefill step's KV was ever stored, so on retrieve the contiguous-prefix match stops at the first un-stored chunk.

## 🏗️ Design Changes

Behavioral change in `MaruSchedulerConnector.build_connector_meta`: chunked-prefill **continuation stores** now run for normally-progressing requests, not only for requests resumed from preemption.

```mermaid
flowchart TB
  subgraph before["Before (bug): resumed gate skips continuations"]
    direction TB
    B1["step 1 - scheduled_new_reqs<br/>prefill tok 0..8191 -> store chunks 0..31"]
    B2["step 2 - scheduled_cached_reqs<br/>resumed? NO -> 'if not resumed: continue' -> SKIP"]
    B3["step 3.. -> SKIP"]
    B1 --> B2 --> B3 --> BR["Maru holds only first 8192 tok"]
  end
  subgraph after["After (fix): continuation stores every step"]
    direction TB
    A1["step 1 -> store chunks 0..31"]
    A2["step 2 (cached, not resumed)<br/>in _requests_need_store -> store chunks 32..63"]
    A3["step 3.. -> store chunks 64.."]
    A1 --> A2 --> A3 --> AR["Maru holds the full prompt"]
  end
  before ~~~ after
```

- Store continuation: now fires for any request still in `_requests_need_store` (resumed or not).
- Load continuation: unchanged — kept resumed-only (preemption reload).

## 📝 Implementation Details

Root cause is the `resumed` gate in the `scheduled_cached_reqs` loop:

```python
for i, req_id in enumerate(cached_reqs.req_ids):
    resumed = req_id in cached_reqs.resumed_req_ids
    if not resumed:
        continue   # skips normal chunked-prefill continuations
```

In vLLM v1, `CachedRequestData.resumed_req_ids` marks **only** requests resumed from preemption. A request advancing through chunked prefill normally appears in `scheduled_cached_reqs` every step but is **not** in `resumed_req_ids`, so this `continue` dropped the store of every step after the first. Only `scheduled_new_reqs` (the first step) ever stored.

The worker `save_kv_layer` was already correct: it uses `num_computed_tokens` as the chunk offset and slices this step's new chunks. The only defect was that the continuation metadata was never built.

The fix removes the gate and separates load vs store:
- **store** continuation runs for any `req_id in self._requests_need_store`;
- **load** continuation stays `resumed and req_id in self._requests_need_load`.

Per the `CachedRequestData` docstring, for non-resumed requests vLLM **appends** `new_block_ids` (the blocks newly allocated this step) to the request's blocks, so the delta blocks + `num_computed_tokens` offset in `save_kv_layer` map exactly to this step's new chunk. (This mirrors how LMCache's connector handles the same case: it processes all cached reqs and uses `resumed_from_preemption` only to restore token ids — never as a skip.)

**Known limitation (follow-up):** a request preempted *mid* chunked-prefill (`resumed=True`) that is still in `_requests_need_store` is not specially handled — for resumed requests `new_block_ids` is a full replacement rather than a delta, which may not align with the `num_computed_tokens` offset in `save_kv_layer`. Rare (preemption during prefill); left for a follow-up.

## ✅ Tests
- [x] Manual tests
- [ ] Unit tests — none added; this path needs a live vLLM + Maru serving stack.

Manual verification (vLLM 0.22.1, Llama-3.1-8B-Instruct, 64k prompts):
- Per-length `/metrics` diff: warm hit rate `8192/ntok` (bug) → ~full reuse (fix).
- naru benchmark (N=15, 64k, repeat-2): external prefix cache hit **9% → 65%**, cold→warm TTFT speedup **1.3× → 4.4×**, no crashes / no pool exhaustion.

## 🔗 Related Issues (optional)
-

## 🌿 Related PRs (optional)
- Builds on #54 (latest vLLM KV cache layout).
