### PR TITLE
feat: expose CXL pool free_size in get_stats

### DIFF
--- a/maru_common/protocol.py
+++ b/maru_common/protocol.py
@@ -446,6 +446,9 @@ class GetStatsResponse:
         default_factory=AllocationManagerStats
     )
     stats_manager: dict = field(default_factory=dict)
+    # Shared CXL device capacity {"total_size", "free_size"} summed across
+    # resource-manager pools; empty when the server omits it (older servers).
+    cxl_pool: dict = field(default_factory=dict)
 
 
 @dataclass

--- a/maru_handler/handler.py
+++ b/maru_handler/handler.py
@@ -792,6 +792,7 @@ class MaruHandler:
                 "active_clients": stats.allocation_manager.active_clients,
             },
             "stats_manager": stats.stats_manager,
+            "cxl_pool": stats.cxl_pool,
         }
 
         if self._owned is not None:

--- a/maru_handler/rpc_client_base.py
+++ b/maru_handler/rpc_client_base.py
@@ -335,6 +335,7 @@ class RpcClientBase(abc.ABC):
                 active_clients=alloc_data.get("active_clients", 0),
             ),
             stats_manager=response.get("stats_manager", {}),
+            cxl_pool=response.get("cxl_pool", {}),
         )
 
     def get_usage(self) -> GetUsageResponse:

--- a/maru_server/server.py
+++ b/maru_server/server.py
@@ -273,10 +273,15 @@ class MaruServer:
 
     def get_stats(self) -> dict:
         """Get server statistics."""
+        pool_total, pool_free = self._pool_totals()
         return {
             "kv_manager": self._kv_manager.get_stats(),
             "allocation_manager": self._allocation_manager.get_stats(),
             "stats_manager": self._stats_manager.get_stats(),
+            # Shared CXL device capacity from the resource manager (summed
+            # across pools). Clients use free_size to size eviction watermarks
+            # against the whole device instead of just their owned pool.
+            "cxl_pool": {"total_size": pool_total, "free_size": pool_free},
         }
 
     def get_usage(self) -> dict:


### PR DESCRIPTION
## Summary

`get_stats` now reports the shared CXL device capacity (`total_size` / `free_size`), summed across resource-manager pools — the same numbers `get_usage` already computes. This lets KV clients (e.g. LMCache's L1 backend) size eviction watermarks against whole-device fill instead of only their own owned pool.

## Key Changes

- `MaruServer.get_stats` adds a `cxl_pool` block `{total_size, free_size}` via the existing `_pool_totals()` (sums `pool_stats()` across RM pools).
- `GetStatsResponse` gains a `cxl_pool: dict` field; `RpcClientBase.get_stats` parses it from the response.
- `MaruHandler.get_stats` surfaces `cxl_pool` in its result dict.
- Backward compatible: the field is empty on older servers, so existing callers are unaffected.

## Test Plan

- [ ] Unit tests added/updated
- [ ] Existing tests pass (`pytest -v`)
- [ ] E2E tests (if applicable)

Manual verification done here:

- Syntax-checked all four files; confirmed `cxl_pool` round-trips server → RPC response → `handler.get_stats()`.
- Additive / backward-compatible — no schema break; empty dict on older servers.
- Exercised end-to-end by an LMCache maru-L1 eviction-watermark change: a benchmark that previously fired 35 spurious evictions (watermark on the owned pool) dropped to 0 once the watermark used `free_size`.

## Related Issues

Builds on the resource-manager pool stats added by the CXL usage monitor (#56).
