### PR TITLE
fix: scope pool totals to --dax-path and serialize RpcClient requests

### DIFF
--- a/maru_handler/rpc_client.py
+++ b/maru_handler/rpc_client.py
@@ -3,6 +3,7 @@
 """RPC Client for connecting to MaruServer."""
 
 import logging
+import threading
 from typing import Any
 
 import zmq
@@ -39,68 +40,84 @@ class RpcClient(RpcClientBase):
         self._context: zmq.Context | None = None
         self._socket: zmq.Socket | None = None
         self._serializer = Serializer()
+        # Serializes socket use: ZMQ sockets are not thread-safe and REQ
+        # additionally enforces strict send->recv alternation, so concurrent
+        # callers (e.g. an eviction loop and a metrics scrape both issuing
+        # get_stats) would otherwise corrupt the socket state.
+        self._lock = threading.Lock()
 
     def connect(self) -> None:
         """Connect to the server."""
-        self._context = zmq.Context()
-        self._socket = self._context.socket(zmq.REQ)
-        self._socket.setsockopt(zmq.RCVTIMEO, self._timeout_ms)
-        self._socket.setsockopt(zmq.SNDTIMEO, self._timeout_ms)
-        self._socket.setsockopt(zmq.LINGER, 0)  # Don't wait on close
-        self._socket.connect(self._server_url)
+        with self._lock:
+            self._context = zmq.Context()
+            self._socket = self._context.socket(zmq.REQ)
+            self._socket.setsockopt(zmq.RCVTIMEO, self._timeout_ms)
+            self._socket.setsockopt(zmq.SNDTIMEO, self._timeout_ms)
+            self._socket.setsockopt(zmq.LINGER, 0)  # Don't wait on close
+            self._socket.connect(self._server_url)
         logger.info("Connected to MaruServer at %s", self._server_url)
 
     def close(self) -> None:
         """Close the connection."""
-        if self._socket:
-            self._socket.close()
-        if self._context:
-            self._context.term()
+        with self._lock:
+            if self._socket:
+                self._socket.close()
+            if self._context:
+                self._context.term()
         logger.info("Disconnected from MaruServer")
 
     def _send_request(
         self, msg_type: MessageType, data: dict[str, Any]
     ) -> dict[str, Any]:
-        """Send a request and wait for response using poll-based timeout."""
-        if self._socket is None:
-            raise RuntimeError("Client not connected. Call connect() first.")
+        """Send a request and wait for response using poll-based timeout.
 
-        try:
-            # Encode and send binary message
-            encoded = self._serializer.encode(msg_type, data)
-            self._socket.send(encoded)
+        Thread-safe: the whole send->poll->recv exchange (including any
+        socket reset) runs under ``self._lock``; concurrent callers queue.
+        """
+        with self._lock:
+            if self._socket is None:
+                raise RuntimeError("Client not connected. Call connect() first.")
 
-            # Poll for response instead of relying on RCVTIMEO exception
-            poller = zmq.Poller()
-            poller.register(self._socket, zmq.POLLIN)
-            events = dict(poller.poll(self._timeout_ms))
+            try:
+                # Encode and send binary message
+                encoded = self._serializer.encode(msg_type, data)
+                self._socket.send(encoded)
 
-            if self._socket not in events:
-                # Timeout: no response within deadline
-                logger.error(
-                    "Timeout waiting for response from server (msg_type=%s)",
-                    msg_type,
-                )
+                # Poll for response instead of relying on RCVTIMEO exception
+                poller = zmq.Poller()
+                poller.register(self._socket, zmq.POLLIN)
+                events = dict(poller.poll(self._timeout_ms))
+
+                if self._socket not in events:
+                    # Timeout: no response within deadline
+                    logger.error(
+                        "Timeout waiting for response from server (msg_type=%s)",
+                        msg_type,
+                    )
+                    try:
+                        self._reset_socket()
+                    except Exception:
+                        logger.warning("Failed to reset socket after timeout")
+                    return {"error": "timeout", "success": False}
+
+                # Data is ready — recv won't block
+                response_data = self._socket.recv(zmq.NOBLOCK)
+                _, payload = self._serializer.decode(response_data)
+                return payload
+            except zmq.ZMQError:
+                logger.error("ZMQ error (msg_type=%s)", msg_type, exc_info=True)
                 try:
                     self._reset_socket()
                 except Exception:
-                    logger.warning("Failed to reset socket after timeout")
+                    logger.warning("Failed to reset socket after error")
                 return {"error": "timeout", "success": False}
 
-            # Data is ready — recv won't block
-            response_data = self._socket.recv(zmq.NOBLOCK)
-            _, payload = self._serializer.decode(response_data)
-            return payload
-        except zmq.ZMQError:
-            logger.error("ZMQ error (msg_type=%s)", msg_type, exc_info=True)
-            try:
-                self._reset_socket()
-            except Exception:
-                logger.warning("Failed to reset socket after error")
-            return {"error": "timeout", "success": False}
-
     def _reset_socket(self) -> None:
-        """Reset socket after timeout (REQ socket needs reset after timeout)."""
+        """Reset socket after timeout (REQ socket needs reset after timeout).
+
+        Called from ``_send_request`` with ``self._lock`` already held; must
+        not re-acquire the lock.
+        """
         if self._socket:
             self._socket.close()
         self._socket = self._context.socket(zmq.REQ)

--- a/maru_server/server.py
+++ b/maru_server/server.py
@@ -278,9 +278,11 @@ class MaruServer:
             "kv_manager": self._kv_manager.get_stats(),
             "allocation_manager": self._allocation_manager.get_stats(),
             "stats_manager": self._stats_manager.get_stats(),
-            # Shared CXL device capacity from the resource manager (summed
-            # across pools). Clients use free_size to size eviction watermarks
-            # against the whole device instead of just their owned pool.
+            # Shared CXL device capacity from the resource manager, summed
+            # across the pools this server may allocate from (--dax-path
+            # scope; all pools when unrestricted). Clients use free_size to
+            # size eviction watermarks against device fill instead of just
+            # their owned pool.
             "cxl_pool": {"total_size": pool_total, "free_size": pool_free},
         }
 
@@ -328,12 +330,23 @@ class MaruServer:
         }
 
     def _pool_totals(self) -> tuple[int, int]:
-        """Return (total_bytes, free_bytes) summed across resource manager pools."""
+        """Return (total_bytes, free_bytes) summed across resource manager pools.
+
+        When the server is restricted to specific devices via ``--dax-path``,
+        only those pools are counted: ``request_alloc`` can only claim regions
+        from the configured pools, so an unrestricted sum would overstate the
+        capacity this server can actually use. Clients size eviction
+        watermarks on ``free_size`` — counting a foreign device's free space
+        defers eviction until allocation fails instead of triggering it.
+        """
         try:
             pools = self._allocation_manager.pool_stats()
         except Exception:
             logger.warning("pool_stats failed during get_usage", exc_info=True)
             return (0, 0)
+        if self._dax_paths:
+            allowed = set(self._dax_paths)
+            pools = [p for p in pools if p.dax_path in allowed]
         return (
             sum(p.total_size for p in pools),
             sum(p.free_size for p in pools),

--- a/tests/unit/test_maru_server.py
+++ b/tests/unit/test_maru_server.py
@@ -191,6 +191,53 @@ class TestGetUsage:
         assert usage["pool_total"] == 300
         assert usage["pool_free"] == 210
 
+    def test_pool_totals_scoped_to_configured_dax_paths(self, monkeypatch):
+        """--dax-path servers count only their own pools in the totals.
+
+        request_alloc can only claim regions from the configured pools, so a
+        foreign device (e.g. a large /dev/dax0.0 used by another deployment)
+        must not inflate pool_free / cxl_pool.free_size — clients size
+        eviction watermarks on it, and counting unusable free space defers
+        eviction until allocation fails.
+        """
+        from maru_shm.types import DaxType, MaruPoolInfo
+
+        server = MaruServer(dax_paths=["/dev/dax1.0", "/dev/dax2.0"])
+        monkeypatch.setattr(
+            server._allocation_manager,
+            "pool_stats",
+            lambda: [
+                MaruPoolInfo(
+                    dax_path="/dev/dax0.0",
+                    dax_type=DaxType.DEV_DAX,
+                    total_size=1000,
+                    free_size=900,
+                    align_bytes=2 << 20,
+                ),
+                MaruPoolInfo(
+                    dax_path="/dev/dax1.0",
+                    dax_type=DaxType.DEV_DAX,
+                    total_size=100,
+                    free_size=60,
+                    align_bytes=2 << 20,
+                ),
+                MaruPoolInfo(
+                    dax_path="/dev/dax2.0",
+                    dax_type=DaxType.DEV_DAX,
+                    total_size=200,
+                    free_size=150,
+                    align_bytes=2 << 20,
+                ),
+            ],
+        )
+
+        usage = server.get_usage()
+        assert usage["pool_total"] == 300
+        assert usage["pool_free"] == 210
+
+        stats = server.get_stats()
+        assert stats["cxl_pool"] == {"total_size": 300, "free_size": 210}
+
     def test_get_usage_pool_stats_failure_is_tolerated(self, monkeypatch):
         """If the RM pool query fails, pool totals fall back to 0."""
         server = MaruServer()

--- a/tests/unit/test_rpc_client.py
+++ b/tests/unit/test_rpc_client.py
@@ -2,6 +2,8 @@
 # Copyright 2026 XCENA Inc.
 """Unit tests for RpcClient to achieve 100% coverage."""
 
+import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -684,3 +686,58 @@ class TestRpcClientApiMethods:
         result = client.heartbeat()
 
         assert result is False
+
+
+class TestRpcClientThreadSafety:
+    """_send_request serializes concurrent callers on the shared REQ socket.
+
+    ZMQ sockets are not thread-safe and REQ enforces strict send->recv
+    alternation, so overlapping exchanges (e.g. an eviction loop and a
+    metrics scrape both issuing get_stats) must queue instead of interleave.
+    """
+
+    def test_concurrent_send_requests_are_serialized(self):
+        """No two send->recv exchanges overlap on the socket."""
+        client = RpcClient(server_url="tcp://127.0.0.1:9999", timeout_ms=1000)
+        client._socket = MagicMock()
+        client._context = MagicMock()
+        client._serializer = MagicMock()
+        client._serializer.encode.return_value = b"encoded"
+        client._serializer.decode.return_value = (MessageType.HEARTBEAT, {"ok": True})
+
+        in_flight = 0
+        max_in_flight = 0
+        counter_lock = threading.Lock()
+
+        def _send(_encoded):
+            nonlocal in_flight, max_in_flight
+            with counter_lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            time.sleep(0.01)  # widen the overlap window
+            with counter_lock:
+                in_flight -= 1
+
+        client._socket.send.side_effect = _send
+
+        with patch("zmq.Poller") as mock_poller:
+            poller_inst = MagicMock()
+            mock_poller.return_value = poller_inst
+            poller_inst.poll.return_value = [(client._socket, zmq.POLLIN)]
+
+            errors: list[Exception] = []
+
+            def _call():
+                try:
+                    client._send_request(MessageType.HEARTBEAT, {})
+                except Exception as e:  # pragma: no cover - failure reporting
+                    errors.append(e)
+
+            threads = [threading.Thread(target=_call) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert not errors
+        assert max_in_flight == 1, "send->recv exchanges overlapped on the socket"


### PR DESCRIPTION
## Summary

Fixes two issues surfaced while wiring the LMCache MP L1 fullness gauges: `get_stats`/`get_usage` summed CXL capacity across **every** resource-manager pool (foreign DAX devices inflate the eviction-watermark total), and the shared ZMQ REQ socket in `RpcClient` corrupts when two threads issue RPCs concurrently (eviction loop + metrics scrape both calling `get_stats`).

## Key Changes

**maru_server — scope `_pool_totals` to the server's `--dax-path` pools**
- `request_alloc` only claims regions from the configured pools, but the totals summed every RM pool. On a host with a foreign device this inflates `cxl_pool.free_size`, which clients use as the eviction-watermark total.
- Observed on a 3-device host: a 3.5 TiB `/dev/dax0.0` pushed the watermark total to ~4 TiB against a 466 GiB usable pair (`dax1.0`+`dax2.0`) — usage ratio stuck at ~5%, so client-side LRU eviction would never engage and stores would run into allocation failure instead.
- `_pool_totals()` now filters by the server's `dax_path` scope; unrestricted servers keep the all-pools behavior. Covers both `get_stats.cxl_pool` (watermark input) and `get_usage.pool_total/pool_free` (marutop).

**maru_handler — serialize `RpcClient` requests with a per-call lock**
- ZMQ sockets are not thread-safe and REQ enforces strict send→recv alternation; overlapping exchanges degrade both calls to spurious timeouts plus socket resets.
- `connect`/`close`/`_send_request` (including the reset paths) now run under one per-instance lock; concurrent callers queue. `_reset_socket` is only called with the lock held.
- No measurable overhead: A/B against a local REP echo server shows sequential mean 59.3µs (main) vs 59.1µs (this branch); an uncontended acquire+release is ~113ns (~0.2% of a roundtrip). Under 2-thread contention, main fails 30/100 calls while this branch fails 0/100 — the lock only ever blocks a caller in the case where main returned garbage.
- The handler's stats flusher uses its own dedicated `RpcClient` (separate lock), so it never contends with the control path. `AsyncRpcClient` is untouched.

## Test Plan

- [x] Unit tests added/updated
  - `test_pool_totals_scoped_to_configured_dax_paths`: foreign pool excluded from `get_usage` and `get_stats.cxl_pool`
  - `TestRpcClientThreadSafety::test_concurrent_send_requests_are_serialized`: 8 threads, no overlapping send→recv exchange
- [x] Existing tests pass (`pytest -v`) — all consumer suites green (`test_maru_server`, `test_rpc_client`, `test_server`, `test_usage_monitor`, `test_rpc_handler_mixin`, `test_allocation_manager`, `test_rpc_async_client`, `test_shm_client`, `test_shm_get_dax_path`; 217 tests). `test_maru_handler.py`/`test_thread_safety.py` bus-error on the dev host identically on clean `main` (live-RM + DAX mmap environment issue, unrelated to this change).
- [x] E2E: against the live resource manager on the 3-device host, a `--dax-path dax1.0,dax2.0` server now reports `cxl_pool` 466 GiB vs 4042 GiB unrestricted.

## Related Issues

Related: #60 (scopes the `cxl_pool` totals introduced there)
