### PR TITLE
fix: coalesce free list after WAL replay in resource manager

### DIFF
--- a/maru_resource_manager/src/pool_manager.cpp
+++ b/maru_resource_manager/src/pool_manager.cpp
@@ -650,6 +650,14 @@ int PoolManager::loadPoolsLocked()
 
     for (auto &pool : stagedPools)
     {
+        // WAL replay returns freed extents via addExtent() (plain push_back,
+        // no merge), so the reconstructed free list is left uncoalesced:
+        // adjacent free regions remain as separate extents. That caps the
+        // largest single allocation at the biggest individual extent, far
+        // below the actual free capacity, even when nothing is allocated.
+        // Coalesce once after replay to restore contiguity (the live free
+        // path already merges inline via insertExtentSorted()).
+        coalesceFreeList(pool);
         recomputeFreeSize(pool);
     }
 
@@ -720,6 +728,8 @@ int PoolManager::rescanDevicesLocked()
     // Commit only after replay succeeds.
     for (auto &pool : stagedPools)
     {
+        // Coalesce the WAL-reconstructed free list (addExtent does not merge).
+        coalesceFreeList(pool);
         recomputeFreeSize(pool);
         pools_.push_back(std::move(pool));
     }


### PR DESCRIPTION
## 🤔 Background & Motivation (Why)

maru-resource-manager 를 재시작하면, 할당/해제 이력이 있는 pool 의 free list 가
**병합되지 않은(조각난) 상태**로 복원됩니다. 그 결과 **총 free 용량은 충분한데도
단일 할당이 가장 큰 조각 크기로 제한**됩니다.

- 실측 (233 GiB `dev-dax` pool): alloc/free churn + 데몬 재시작 후 free list 가
  `[0, 200 GiB]` + `[200, 33 GiB]` (총 free 232 GiB) 로 남아, **200+ GiB 단일 pool
  할당이 `-ENOMEM`** 으로 실패. 반면 `stats`/`marutop` 은 여전히 ~233 GiB free 로
  표시되어 원인 파악이 어렵습니다. 할당 이력이 전혀 없던 pool 은 `[0, 233 GiB]`
  단일 extent 로 정상.
- 이 상태에서 큰 pool 을 한 번에 잡는 클라이언트(예: vLLM 직결 `MaruKVConnector`)가
  걸립니다. scheduler(4 MiB 메타 pool) + worker(예: 200 GiB) 를 같은 device 에 올릴 때,
  200 GiB 가 이미 "가장 큰 free 조각" 과 같은 크기라 **4 MiB 선점만으로도 worker
  할당이 실패**합니다.

## 🏗️ Design Changes

데몬 재시작 시 각 pool 의 free list 는 WAL replay 로 재구성됩니다. 기존에는 replay 가
해제 extent 를 **병합 없이** 되돌리고 이후에도 coalesce 를 하지 않아, free list 가
**단편화된 채** 커밋됐습니다. 이번 변경은 **replay 완료 후 한 번 coalesce** 하여 인접
free 조각을 합쳐 연속성을 회복합니다. (live free 경로는 이미 `insertExtentSorted` 로
inline 병합하고 있어, replay 경로만 동작이 어긋나 있었습니다.)

**Before** — replay 가 free list 를 조각난 채로 남김:

```mermaid
flowchart TD
    A["daemon 재시작"] --> B["checkpoint 로드 + WAL replay"]
    B --> C["FREE 레코드 = addExtent : push_back, 병합 없음<br/>replay 후 coalesce 호출도 없음"]
    C --> D["free list 단편화<br/>ex1 0..200G , ex2 200..233G (분리)"]
    D --> E["단일 할당 최대 = 200G<br/>총 free 232G 인데 201G+ 요청은 -ENOMEM"]
```

**After** — replay 후 coalesce 로 연속성 회복:

```mermaid
flowchart TD
    A["daemon 재시작"] --> B["checkpoint 로드 + WAL replay"]
    B --> C["coalesceFreeList(pool) 추가 호출"]
    C --> D["free list 병합<br/>ex 0..233G 단일 extent"]
    D --> E["단일 할당 최대 = 233G (총 free 와 일치)"]
```

## 📝 Implementation Details

- `coalesceFreeList()` 는 이미 구현돼 있었으나 **호출부가 하나도 없는 dead code** 였습니다.
- WAL replay 의 FREE 처리 `addExtent()` 는 단순 `push_back` 으로 인접 extent 를 병합하지 않습니다
  (`wal.cpp`).
- `loadPoolsLocked()` 와 `rescanDevicesLocked()` 의 replay 완료 loop 에서 `recomputeFreeSize()`
  직전에 **`coalesceFreeList(pool)` 를 호출**하도록 추가했습니다 (2곳).
- 이 coalesce 는 checkpoint(`pool_N.meta`)에서 로드된 조각난 리스트에도 적용되므로, fix 반영
  후 **첫 재시작에서 기존 단편화 상태도 자가 치유**됩니다.
- `insertExtentSorted()`(live free) 는 그대로 두었습니다 — 이미 inline 병합하고 있어 영향 없음.

## ✅ Tests
- [x] Manual tests — 실 `dev-dax` 에서 재현·검증: 재시작 후 free list `[200]+[33]` → 200 GiB
  단일 할당 `-ENOMEM`(marutop 은 free 233 표시). 코드 빌드 OK, 기존 유닛테스트 16개 전부 통과.
- [ ] Unit tests — replay-후-coalesce 를 커버하는 유닛테스트는 device-scan mocking(테스트 훅)이
  필요해 후속으로 추가 예정. (그래서 우선 **draft** 로 올립니다.)
- [ ] Integration tests

## 🔗 Related Issues (optional)
-
