### PR TITLE
feat: chunked CUDA host registration with eager/lazy pin modes

### DIFF
--- a/maru_handler/memory/mapper.py
+++ b/maru_handler/memory/mapper.py
@@ -24,6 +24,34 @@ _MADV_POPULATE_WRITE = getattr(mmap_module, "MADV_POPULATE_WRITE", 23)
 _PREFAULT_ENABLED = os.environ.get("MARU_PREFAULT", "1") != "0"
 _PAGE_SIZE = os.sysconf("SC_PAGESIZE") if hasattr(os, "sysconf") else 4096
 
+# CUDA pinning strategy.
+#
+# A single cudaHostRegister call fails with cudaErrorMemoryAllocation for
+# ranges >= 2^39 bytes (512 GiB) — the NVIDIA kernel driver cannot build a
+# page table for one mapping that large ("NVRM: failed to allocate page
+# table").  The limit is per call, not cumulative, so large regions are
+# registered in chunks.
+#
+#   MARU_PIN_MODE:     "eager" (default) — register all chunks synchronously
+#                      inside map_region(); the region is fully pinned when
+#                      map_region() returns.
+#                      "lazy" — return immediately and register chunks in a
+#                      background thread (LMCache LazyMemoryAllocator style).
+#                      Chunks not yet pinned degrade GPU DMA to pageable
+#                      copies but remain fully usable.
+#   MARU_PIN_CHUNK_GB: chunk size in GiB (default 128, clamped to 256 so a
+#                      chunk can never reach the 512 GiB wall; 0 = single
+#                      call, i.e. the pre-chunking behavior).
+_PIN_MODE = os.environ.get("MARU_PIN_MODE", "eager")
+if _PIN_MODE not in ("eager", "lazy"):
+    _PIN_MODE = "eager"
+try:
+    _PIN_CHUNK_BYTES = int(os.environ.get("MARU_PIN_CHUNK_GB", "128")) << 30
+except ValueError:
+    _PIN_CHUNK_BYTES = 128 << 30
+if _PIN_CHUNK_BYTES > 256 << 30:
+    _PIN_CHUNK_BYTES = 256 << 30
+
 
 def _clear_cuda_sticky_error() -> None:
     """Consume CUDA's per-thread sticky error after a failed cudaHostRegister.
@@ -47,6 +75,67 @@ def _clear_cuda_sticky_error() -> None:
             lib.cudaGetLastError()
     except (OSError, IndexError, AttributeError):
         logger.debug("could not clear CUDA sticky error", exc_info=True)
+
+
+def _cuda_pin_chunks(
+    cudart,
+    base_addr: int,
+    length: int,
+    region_id: int,
+    records: list[tuple[int, int]],
+    stop_event: threading.Event | None = None,
+) -> None:
+    """Register [base_addr, base_addr+length) with CUDA in chunks.
+
+    Appends an (addr, size) record to ``records`` for every successfully
+    registered chunk (records are what cudaHostUnregister must be called
+    with later).  A failed chunk is logged and its sticky CUDA error
+    cleared; pinning continues so the remaining chunks still get DMA.
+    """
+    chunk = _PIN_CHUNK_BYTES if _PIN_CHUNK_BYTES > 0 else length
+    off = 0
+    while off < length:
+        if stop_event is not None and stop_event.is_set():
+            return
+        n = min(chunk, length - off)
+        rc = cudart.cudaHostRegister(base_addr + off, n, 0)
+        rc = int(rc[0]) if isinstance(rc, tuple) else int(rc)
+        if rc == 0:
+            records.append((base_addr + off, n))
+        else:
+            _clear_cuda_sticky_error()
+            logger.warning(
+                "cudaHostRegister failed for region %d chunk [+%d, +%d): "
+                "rc=%d; chunk stays unpinned (GPU DMA degraded)",
+                region_id,
+                off,
+                off + n,
+                rc,
+            )
+        off += n
+
+
+def _cuda_unpin_records(
+    cudart, records: list[tuple[int, int]], region_id: int
+) -> None:
+    """Unregister every previously pinned chunk of a region."""
+    for addr, _size in records:
+        try:
+            rc = cudart.cudaHostUnregister(addr)
+            rc = int(rc[0]) if isinstance(rc, tuple) else int(rc)
+            if rc != 0:
+                _clear_cuda_sticky_error()
+                logger.warning(
+                    "cudaHostUnregister failed for region %d addr=%#x: rc=%d",
+                    region_id,
+                    addr,
+                    rc,
+                )
+        except (RuntimeError, OSError) as e:
+            logger.warning(
+                "cudaHostUnregister failed for region %d: %s", region_id, e
+            )
+    records.clear()
 
 
 class DaxMapper:
@@ -127,6 +216,15 @@ class DaxMapper:
             )
             self._regions[region_id] = region
 
+            # Base address for CUDA pinning — resolved while the lock still
+            # guarantees the buffer view is alive (a concurrent unmap after
+            # publication would otherwise race the from_buffer export).
+            pin_addr = (
+                ctypes.addressof(ctypes.c_char.from_buffer(region._buffer_view))
+                if region._buffer_view is not None
+                else None
+            )
+
             logger.debug(
                 "Mapped region %d: length=%d",
                 region_id,
@@ -140,43 +238,55 @@ class DaxMapper:
             prefault_ms = (time.monotonic() - t0) * 1000
 
         # Outside lock: CUDA pin is idempotent
-        if region._buffer_view is not None:
+        if pin_addr is not None:
             try:
                 import torch
 
                 if torch.cuda.is_available():
-                    addr = ctypes.addressof(
-                        ctypes.c_char.from_buffer(region._buffer_view)
-                    )
-                    t0 = time.monotonic()
-                    rc = torch.cuda.cudart().cudaHostRegister(
-                        addr, handle.length, 0
-                    )
-                    cuda_pin_ms = (time.monotonic() - t0) * 1000
-                    rc = int(rc[0]) if isinstance(rc, tuple) else int(rc)
-                    if rc == 0:
-                        region._cuda_pinned = True
+                    cudart = torch.cuda.cudart()
+                    if _PIN_MODE == "lazy":
+                        thread = threading.Thread(
+                            target=self._pin_worker,
+                            args=(cudart, region, pin_addr, handle.length),
+                            daemon=True,
+                            name=f"maru-pin-{region_id}",
+                        )
+                        thread.start()
+                        # Published only after a successful start() so unmap
+                        # never joins a never-started thread.
+                        region._pin_thread = thread
                         logger.info(
-                            "CUDA pinned region %d (%d bytes)",
+                            "CUDA pinning region %d in background (%d bytes)",
                             region_id,
                             handle.length,
                         )
                     else:
-                        # NVIDIA r580+ drivers reject a single registration
-                        # of >= 512 GiB (per-registration page table hits
-                        # the kernel's kvmalloc INT_MAX cap: "NVRM: failed
-                        # to allocate page table"). Clear the per-thread
-                        # sticky error so an unrelated later CUDA call does
-                        # not crash with a misattributed OOM.
-                        _clear_cuda_sticky_error()
-                        logger.warning(
-                            "cudaHostRegister failed for region %d "
-                            "(%d bytes): rc=%d — region stays unpinned, "
-                            "GPU transfers fall back to pageable copies",
-                            region_id,
-                            handle.length,
-                            rc,
-                        )
+                        t0 = time.monotonic()
+                        with region._pin_lock:
+                            _cuda_pin_chunks(
+                                cudart, pin_addr, handle.length, region_id,
+                                region._pin_records,
+                                stop_event=region._pin_stop,
+                            )
+                            pinned = sum(n for _, n in region._pin_records)
+                            n_chunks = len(region._pin_records)
+                        cuda_pin_ms = (time.monotonic() - t0) * 1000
+                        if pinned == handle.length:
+                            logger.info(
+                                "CUDA pinned region %d (%d bytes, %d chunks)",
+                                region_id,
+                                pinned,
+                                n_chunks,
+                            )
+                        else:
+                            logger.warning(
+                                "CUDA pinned region %d PARTIALLY: %d/%d bytes"
+                                " — unpinned ranges fall back to pageable"
+                                " copies",
+                                region_id,
+                                pinned,
+                                handle.length,
+                            )
             except (ImportError, RuntimeError, OSError) as e:
                 if not isinstance(e, ImportError):
                     logger.warning(
@@ -198,6 +308,91 @@ class DaxMapper:
         )
 
         return region
+
+    @staticmethod
+    def _cuda_unpin_region(region) -> None:
+        """Stop/join any in-flight pinning, then unregister pinned chunks.
+
+        Setting _pin_stop makes a concurrent pin loop (eager in another
+        thread, or the lazy worker) exit at its next chunk boundary, so
+        acquiring _pin_lock below waits for at most one chunk.
+        """
+        region._pin_stop.set()
+        if region._pin_thread is not None:
+            region._pin_thread.join()
+            region._pin_thread = None
+        with region._pin_lock:
+            if not region._pin_records:
+                return
+            try:
+                import torch
+
+                if torch.cuda.is_available():
+                    _cuda_unpin_records(
+                        torch.cuda.cudart(),
+                        region._pin_records,
+                        region.region_id,
+                    )
+            except (ImportError, RuntimeError, OSError) as e:
+                if not isinstance(e, ImportError):
+                    logger.warning(
+                        "cudaHostUnregister failed for region %d: %s",
+                        region.region_id,
+                        e,
+                    )
+
+    def _pin_worker(
+        self, cudart, region, base_addr: int, length: int
+    ) -> None:
+        """Background chunk-pinning worker (MARU_PIN_MODE=lazy).
+
+        Appends to region._pin_records as chunks are registered so that
+        unmap_region()/close() — which join this thread first — always
+        unregister exactly what was pinned.
+        """
+        t0 = time.monotonic()
+        try:
+            with region._pin_lock:
+                _cuda_pin_chunks(
+                    cudart,
+                    base_addr,
+                    length,
+                    region.region_id,
+                    region._pin_records,
+                    stop_event=region._pin_stop,
+                )
+                pinned = sum(n for _, n in region._pin_records)
+        except (RuntimeError, OSError) as e:
+            logger.warning(
+                "cudaHostRegister failed for region %d: %s",
+                region.region_id,
+                e,
+            )
+            return
+        if region._pin_stop.is_set() and pinned < length:
+            logger.info(
+                "CUDA background pinning region %d cancelled at %d/%d bytes",
+                region.region_id,
+                pinned,
+                length,
+            )
+        elif pinned < length:
+            logger.warning(
+                "CUDA background pinning region %d PARTIAL: %d/%d bytes — "
+                "unpinned ranges fall back to pageable copies",
+                region.region_id,
+                pinned,
+                length,
+            )
+        else:
+            logger.info(
+                "CUDA background pinning region %d finished: %d/%d bytes "
+                "in %.1f ms",
+                region.region_id,
+                pinned,
+                length,
+                (time.monotonic() - t0) * 1000,
+            )
 
     @staticmethod
     def _prefault_region(mmap_obj: mmap_module.mmap, region_id: int, size: int) -> None:
@@ -248,33 +443,9 @@ class DaxMapper:
                 return False
 
             try:
-                # CUDA unpin before munmap (order matters — needs buffer_view for addr)
-                if region._cuda_pinned and region._buffer_view is not None:
-                    try:
-                        import torch
-
-                        if torch.cuda.is_available():
-                            addr = ctypes.addressof(
-                                ctypes.c_char.from_buffer(region._buffer_view)
-                            )
-                            rc = torch.cuda.cudart().cudaHostUnregister(addr)
-                            rc = int(rc[0]) if isinstance(rc, tuple) else int(rc)
-                            if rc != 0:
-                                _clear_cuda_sticky_error()
-                                logger.warning(
-                                    "cudaHostUnregister failed for region "
-                                    "%d: rc=%d",
-                                    region_id,
-                                    rc,
-                                )
-                            region._cuda_pinned = False
-                    except (ImportError, RuntimeError, OSError) as e:
-                        if not isinstance(e, ImportError):
-                            logger.warning(
-                                "cudaHostUnregister failed for region %d: %s",
-                                region_id,
-                                e,
-                            )
+                # CUDA unpin before munmap (join lazy pin thread first so
+                # _pin_records is final, then unregister each pinned chunk)
+                self._cuda_unpin_region(region)
 
                 if region.is_mapped:
                     region.release()
@@ -330,32 +501,7 @@ class DaxMapper:
                     continue
                 try:
                     # CUDA unpin before munmap (order matters!)
-                    if region._cuda_pinned and region._buffer_view is not None:
-                        try:
-                            import torch
-
-                            if torch.cuda.is_available():
-                                addr = ctypes.addressof(
-                                    ctypes.c_char.from_buffer(region._buffer_view)
-                                )
-                                rc = torch.cuda.cudart().cudaHostUnregister(addr)
-                                rc = int(rc[0]) if isinstance(rc, tuple) else int(rc)
-                                if rc != 0:
-                                    _clear_cuda_sticky_error()
-                                    logger.warning(
-                                        "cudaHostUnregister failed for region "
-                                        "%d: rc=%d",
-                                        rid,
-                                        rc,
-                                    )
-                                region._cuda_pinned = False
-                        except (ImportError, RuntimeError, OSError) as e:
-                            if not isinstance(e, ImportError):
-                                logger.warning(
-                                    "cudaHostUnregister failed for region %d: %s",
-                                    rid,
-                                    e,
-                                )
+                    self._cuda_unpin_region(region)
 
                     if region.is_mapped:
                         region.release()

--- a/maru_handler/memory/types.py
+++ b/maru_handler/memory/types.py
@@ -4,6 +4,7 @@
 
 import logging
 import mmap as mmap_module
+import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -31,9 +32,24 @@ class MappedRegion:
     _mmap_obj: mmap_module.mmap | None = field(default=None, repr=False)
     # memoryview of the entire mmap — created eagerly in __post_init__
     _buffer_view: memoryview | None = field(default=None, repr=False, init=False)
-    # True only when cudaHostRegister actually succeeded (rc == 0), so
-    # unmap/close know whether cudaHostUnregister is needed
-    _cuda_pinned: bool = field(default=False, repr=False, init=False)
+    # (addr, size) per successfully cudaHostRegister'ed chunk — the exact
+    # base addresses cudaHostUnregister must be called with on unmap
+    _pin_records: list[tuple[int, int]] = field(
+        default_factory=list, repr=False, init=False
+    )
+    # Serializes the chunk-pin loop against unmap-time unpinning; _pin_stop
+    # makes an in-flight pin loop exit at the next chunk boundary so unpin
+    # never waits for more than one chunk.
+    _pin_lock: threading.Lock = field(
+        default_factory=threading.Lock, repr=False, init=False
+    )
+    _pin_stop: threading.Event = field(
+        default_factory=threading.Event, repr=False, init=False
+    )
+    # Background pinning thread (MARU_PIN_MODE=lazy only)
+    _pin_thread: threading.Thread | None = field(
+        default=None, repr=False, init=False
+    )
 
     def __post_init__(self):
         if self._mmap_obj is not None:

--- a/maru_vllm/connector.py
+++ b/maru_vllm/connector.py
@@ -710,9 +710,13 @@ class MaruWorkerConnector:
                             )
                             success = False
                             break
-                        # CXL mmap is already cudaHostRegistered by
-                        # DaxMapper — no clone() needed, .cuda() uses
-                        # DMA directly from pinned CXL memory
+                        # CXL mmap is cudaHostRegistered by DaxMapper
+                        # (fully, before map_region returns, with the
+                        # default MARU_PIN_MODE=eager) — no clone() needed,
+                        # .cuda() uses DMA directly from pinned CXL memory.
+                        # With MARU_PIN_MODE=lazy or after a chunk pin
+                        # failure, unpinned ranges still work but fall back
+                        # to pageable copies.
                         chunk_tensor = torch.frombuffer(
                             info.view, dtype=kv_cache_layer.dtype
                         )

--- a/tests/unit/test_mapper.py
+++ b/tests/unit/test_mapper.py
@@ -189,22 +189,72 @@ class TestDaxMapperCudaPin:
         assert region.is_mapped
 
 
-class TestDaxMapperPinRcCheck:
-    """cudaHostRegister return-code checking (previously ignored)."""
+class TestDaxMapperChunkedPin:
+    """Test chunked cudaHostRegister (512GiB-per-call driver limit workaround)."""
 
-    def test_register_rc_failure_warns_and_skips_unregister(self, monkeypatch):
-        """rc != 0 → warning, region unpinned, no unregister on unmap."""
+    def test_chunked_register_calls(self, monkeypatch):
+        """Region larger than the chunk size is registered in multiple calls."""
+        import maru_handler.memory.mapper as mapper_mod
+
+        monkeypatch.setattr(mapper_mod, "_PIN_CHUNK_BYTES", 1024)
+        mock_torch, mock_cudart = _mock_torch_cuda()
+
+        mapper = DaxMapper()
+        handle = _make_handle(1, 4096)
+
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            region = mapper.map_region(handle)
+
+        base = ctypes.addressof(ctypes.c_char.from_buffer(region._buffer_view))
+        calls = mock_cudart.cudaHostRegister.call_args_list
+        assert [c.args for c in calls] == [
+            (base, 1024, 0),
+            (base + 1024, 1024, 0),
+            (base + 2048, 1024, 0),
+            (base + 3072, 1024, 0),
+        ]
+        assert region._pin_records == [
+            (base, 1024),
+            (base + 1024, 1024),
+            (base + 2048, 1024),
+            (base + 3072, 1024),
+        ]
+
+    def test_chunked_unregister_per_record(self, monkeypatch):
+        """Unmap unregisters each pinned chunk's base address."""
+        import maru_handler.memory.mapper as mapper_mod
+
+        monkeypatch.setattr(mapper_mod, "_PIN_CHUNK_BYTES", 2048)
+        mock_torch, mock_cudart = _mock_torch_cuda()
+
+        mapper = DaxMapper()
+        handle = _make_handle(1, 4096)
+
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            region = mapper.map_region(handle)
+            base = ctypes.addressof(
+                ctypes.c_char.from_buffer(region._buffer_view)
+            )
+            mapper.unmap_region(1)
+
+        assert [c.args for c in mock_cudart.cudaHostUnregister.call_args_list] == [
+            (base,),
+            (base + 2048,),
+        ]
+
+    def test_register_failure_rc_checked(self, monkeypatch):
+        """Non-zero cudaHostRegister rc → warning, no record, error cleared."""
         import logging
 
         import maru_handler.memory.mapper as mapper_mod
+
+        mock_torch, mock_cudart = _mock_torch_cuda()
+        mock_cudart.cudaHostRegister.return_value = (2,)  # cudaErrorMemoryAllocation
 
         cleared = []
         monkeypatch.setattr(
             mapper_mod, "_clear_cuda_sticky_error", lambda: cleared.append(1)
         )
-
-        mock_torch, mock_cudart = _mock_torch_cuda()
-        mock_cudart.cudaHostRegister.return_value = (2,)  # cudaErrorMemoryAllocation
 
         mapper = DaxMapper()
         handle = _make_handle(1, 4096)
@@ -216,14 +266,44 @@ class TestDaxMapperPinRcCheck:
                 region = mapper.map_region(handle)
             mapper.unmap_region(1)
 
-        assert region._cuda_pinned is False
+        assert region._pin_records == []
         assert cleared == [1]
-        assert mock_warning.called
-        assert "cudaHostRegister failed" in mock_warning.call_args[0][0]
+        warnings = [c.args[0] for c in mock_warning.call_args_list]
+        assert any("cudaHostRegister failed" in w for w in warnings)
+        assert any("PARTIALLY" in w for w in warnings)
         mock_cudart.cudaHostUnregister.assert_not_called()
 
-    def test_register_rc_success_sets_pinned_and_unregisters(self):
-        """rc == 0 → pinned flag set, unmap unregisters once."""
+    def test_partial_register_failure(self, monkeypatch):
+        """One failed chunk is skipped; the others are pinned and unpinned."""
+        import maru_handler.memory.mapper as mapper_mod
+
+        monkeypatch.setattr(mapper_mod, "_PIN_CHUNK_BYTES", 1024)
+        monkeypatch.setattr(mapper_mod, "_clear_cuda_sticky_error", lambda: None)
+        mock_torch, mock_cudart = _mock_torch_cuda()
+        mock_cudart.cudaHostRegister.side_effect = [(0,), (2,), (0,), (0,)]
+
+        mapper = DaxMapper()
+        handle = _make_handle(1, 4096)
+
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            region = mapper.map_region(handle)
+            base = ctypes.addressof(
+                ctypes.c_char.from_buffer(region._buffer_view)
+            )
+            assert region._pin_records == [
+                (base, 1024),
+                (base + 2048, 1024),
+                (base + 3072, 1024),
+            ]
+            mapper.unmap_region(1)
+
+        assert mock_cudart.cudaHostUnregister.call_count == 3
+
+    def test_single_call_mode_chunk_zero(self, monkeypatch):
+        """MARU_PIN_CHUNK_GB=0 registers the whole region in one call."""
+        import maru_handler.memory.mapper as mapper_mod
+
+        monkeypatch.setattr(mapper_mod, "_PIN_CHUNK_BYTES", 0)
         mock_torch, mock_cudart = _mock_torch_cuda()
 
         mapper = DaxMapper()
@@ -231,10 +311,85 @@ class TestDaxMapperPinRcCheck:
 
         with patch.dict("sys.modules", {"torch": mock_torch}):
             region = mapper.map_region(handle)
-            assert region._cuda_pinned is True
+
+        base = ctypes.addressof(ctypes.c_char.from_buffer(region._buffer_view))
+        mock_cudart.cudaHostRegister.assert_called_once_with(base, 4096, 0)
+
+    def test_stop_event_truncates_pinning(self, monkeypatch):
+        """A pre-set stop event makes the pin loop register nothing."""
+        import maru_handler.memory.mapper as mapper_mod
+
+        monkeypatch.setattr(mapper_mod, "_PIN_CHUNK_BYTES", 1024)
+        mock_torch, mock_cudart = _mock_torch_cuda()
+
+        mapper = DaxMapper()
+        handle = _make_handle(1, 4096)
+
+        # Pre-set the stop flag via the dataclass default the region will
+        # get — simulate by patching _cuda_pin_chunks call path: map, then
+        # verify unmap-after-stop unregisters exactly what was pinned.
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            region = mapper.map_region(handle)
+            region._pin_stop.set()
+            # a second pin loop over the same region would now no-op
+            mapper_mod._cuda_pin_chunks(
+                mock_cudart,
+                0x1000,
+                4096,
+                1,
+                [],
+                stop_event=region._pin_stop,
+            )
             mapper.unmap_region(1)
 
-        mock_cudart.cudaHostUnregister.assert_called_once()
+        # 4 chunks from map_region only — the stopped loop added none
+        assert mock_cudart.cudaHostRegister.call_count == 4
+        assert mock_cudart.cudaHostUnregister.call_count == 4
+
+    def test_lazy_close_joins_and_unregisters(self, monkeypatch):
+        """close() in lazy mode joins the worker and unregisters chunks."""
+        import maru_handler.memory.mapper as mapper_mod
+
+        monkeypatch.setattr(mapper_mod, "_PIN_MODE", "lazy")
+        monkeypatch.setattr(mapper_mod, "_PIN_CHUNK_BYTES", 2048)
+        mock_torch, mock_cudart = _mock_torch_cuda()
+
+        mapper = DaxMapper()
+
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            r1 = mapper.map_region(_make_handle(1, 4096))
+            r2 = mapper.map_region(_make_handle(2, 4096))
+            for r in (r1, r2):
+                if r._pin_thread is not None:
+                    r._pin_thread.join(timeout=5)
+            mapper.close()
+
+        assert mock_cudart.cudaHostRegister.call_count == 4
+        assert mock_cudart.cudaHostUnregister.call_count == 4
+        assert r1._pin_thread is None and r2._pin_thread is None
+        assert mapper.get_region(1) is None and mapper.get_region(2) is None
+
+    def test_lazy_mode_pins_in_background(self, monkeypatch):
+        """MARU_PIN_MODE=lazy pins on a background thread; unmap joins it."""
+        import maru_handler.memory.mapper as mapper_mod
+
+        monkeypatch.setattr(mapper_mod, "_PIN_MODE", "lazy")
+        monkeypatch.setattr(mapper_mod, "_PIN_CHUNK_BYTES", 1024)
+        mock_torch, mock_cudart = _mock_torch_cuda()
+
+        mapper = DaxMapper()
+        handle = _make_handle(1, 4096)
+
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            region = mapper.map_region(handle)
+            assert region._pin_thread is not None
+            region._pin_thread.join(timeout=5)
+            assert len(region._pin_records) == 4
+            mapper.unmap_region(1)
+
+        assert mock_cudart.cudaHostRegister.call_count == 4
+        assert mock_cudart.cudaHostUnregister.call_count == 4
+        assert region._pin_thread is None
 
 
 class TestDaxMapperErrorPaths:


### PR DESCRIPTION
> **Stacked on #65** (`fix/pin-rc-check`) — merge that first. #65 is the minimal rc-check + sticky-error-clear fix; this PR adds chunked registration on top so >= 512 GiB pools actually pin (and replaces #65's single `_cuda_pinned` flag with per-chunk records).

## Problem

A single `cudaHostRegister` call of **>= 2^39 bytes (512 GiB)** fails with `cudaErrorMemoryAllocation` on NVIDIA r580+ drivers. The driver builds a flat 16 B-per-4 KiB-page bookkeeping table per registration via `kvzalloc()`, which Linux caps at `INT_MAX` (512 GiB x 16 B / 4 KiB = 2^31 = INT_MAX + 1). The kernel logs `NVRM: failed to allocate page table`. The cap is **per call**, not cumulative — N smaller registrations totaling well above 512 GiB succeed. Drivers <= 575.x are unaffected (different allocation scheme); current upstream main still has it.

On top of that, `DaxMapper.map_region()` ignored the `cudaHostRegister` return code, so with `pool_size > ~510` the pin failed silently, logged "CUDA pinned region ..." anyway, and the latched CUDA sticky error blew up the next kernel launch on the same thread as a misattributed crash:

```
torch.AcceleratorError: CUDA error: out of memory   (at vLLM flashinfer autotune sm.fill_)
```

Reproduced with `pool_size: "520"` on gaia (`/dev/dax0.0`): startup died in EngineCore; measured boundary 510 GiB OK / 512 GiB FAIL; 300+300+100+50 = 750 GiB chunked registrations OK.

## Change

`DaxMapper` now registers regions in chunks and actually checks the result:

- **Chunked registration** — `MARU_PIN_CHUNK_GB` (default 128, `0` = single call). Each chunk is registered separately; per-chunk `(addr, size)` records live on `MappedRegion._pin_records` and are individually `cudaHostUnregister`ed on unmap/close.
- **Return-code check + sticky-error clearing** — a failed chunk logs the exact offset range and consumes the per-thread CUDA sticky error via the already-loaded `libcudart` (found in `/proc/self/maps`), so an unrelated later kernel launch no longer crashes. Failed chunks degrade to pageable copies instead of killing startup.
- **Pin modes** — `MARU_PIN_MODE=eager` (default): all chunks registered synchronously inside `map_region()`, preserving the "fully pinned on return" contract. `MARU_PIN_MODE=lazy`: chunks are registered by a background thread (LMCache LazyMemoryAllocator style); unmap/close joins the thread before unregistering. Lazy trades a short degraded-DMA window for instant startup on multi-TiB pools.

## Verification

- `tests/unit/test_mapper.py`: 5 new tests (chunk call layout, per-record unregister, rc-failure path, partial failure, lazy mode); full unit suite 766 passed.
- E2E on gaia: `pool_size: "520"` + Llama-3.1-8B + lveval 64k — previously crashed at startup, now `CUDA pinned region 2365 (558345748480 bytes, 5 chunks)`, `cuda_pin=4450ms`, benchmark 20/20 ok, cache-hit TTFT 1.8 s (warmup 16.4 s).

Driver-side root cause is being reported to NVIDIA (open-gpu-kernel-modules) separately; this change is safe on all driver versions.

