### PR TITLE
fix: check cudaHostRegister return code and clear CUDA sticky error

### DIFF
--- a/maru_handler/memory/mapper.py
+++ b/maru_handler/memory/mapper.py
@@ -25,28 +25,63 @@ _PREFAULT_ENABLED = os.environ.get("MARU_PREFAULT", "1") != "0"
 _PAGE_SIZE = os.sysconf("SC_PAGESIZE") if hasattr(os, "sysconf") else 4096
 
 
+def _cuda_rc(ret) -> int:
+    """Normalize torch cudart's return value (enum, int, or 1-tuple) to int."""
+    return int(ret[0]) if isinstance(ret, tuple) else int(ret)
+
+
+def _find_libcudart_paths() -> list[str]:
+    """Return every distinct libcudart mapped into this process.
+
+    Matches on the basename so torch wheels that bundle a hashed copy
+    (``libcudart-<hash>.so.X``) are found too, and strips the
+    ``" (deleted)"`` suffix /proc/self/maps appends to unlinked files.
+    """
+    paths: list[str] = []
+    with open("/proc/self/maps") as f:
+        for line in f:
+            fields = line.rstrip("\n").split(maxsplit=5)
+            if len(fields) < 6:
+                continue
+            path = fields[5]
+            if path.endswith(" (deleted)"):
+                path = path[: -len(" (deleted)")]
+            if "libcudart" in os.path.basename(path) and path not in paths:
+                paths.append(path)
+    return paths
+
+
 def _clear_cuda_sticky_error() -> None:
     """Consume CUDA's per-thread sticky error after a failed cudaHostRegister.
 
     torch's cudart binding does not expose cudaGetLastError, so locate the
-    libcudart torch itself loaded (dlopen of the same path returns the
-    already-loaded instance) and consume the error there.  Without this, the
-    next error-checked CUDA call on this thread — typically an unrelated
-    kernel launch — raises a misattributed "CUDA error: out of memory".
+    libcudart instance(s) loaded in this process (dlopen of the same path
+    returns the already-loaded instance) and consume the error there.  The
+    error state is per instance, so every mapped copy is cleared.  Without
+    this, the next error-checked CUDA call on this thread — typically an
+    unrelated kernel launch — raises a misattributed
+    "CUDA error: out of memory".
     """
+    cleared = False
     try:
-        path = None
-        with open("/proc/self/maps") as f:
-            for line in f:
-                if "libcudart.so" in line:
-                    path = line.rstrip("\n").split(maxsplit=5)[-1]
-                    break
-        if path:
-            lib = ctypes.CDLL(path)
-            lib.cudaGetLastError.restype = ctypes.c_int
-            lib.cudaGetLastError()
-    except (OSError, IndexError, AttributeError):
-        logger.debug("could not clear CUDA sticky error", exc_info=True)
+        for path in _find_libcudart_paths():
+            try:
+                lib = ctypes.CDLL(path)
+                lib.cudaGetLastError.restype = ctypes.c_int
+                lib.cudaGetLastError()
+                cleared = True
+            except (OSError, AttributeError):
+                logger.debug(
+                    "could not clear CUDA sticky error via %s", path, exc_info=True
+                )
+    except OSError:
+        pass
+    if not cleared:
+        logger.warning(
+            "could not clear CUDA sticky error (no loadable libcudart in "
+            "/proc/self/maps) — the next CUDA call on this thread may raise "
+            "a misattributed error"
+        )
 
 
 class DaxMapper:
@@ -149,9 +184,10 @@ class DaxMapper:
                         ctypes.c_char.from_buffer(region._buffer_view)
                     )
                     t0 = time.monotonic()
-                    rc = torch.cuda.cudart().cudaHostRegister(addr, handle.length, 0)
+                    rc = _cuda_rc(
+                        torch.cuda.cudart().cudaHostRegister(addr, handle.length, 0)
+                    )
                     cuda_pin_ms = (time.monotonic() - t0) * 1000
-                    rc = int(rc[0]) if isinstance(rc, tuple) else int(rc)
                     if rc == 0:
                         region._cuda_pinned = True
                         logger.info(
@@ -247,31 +283,7 @@ class DaxMapper:
 
             try:
                 # CUDA unpin before munmap (order matters — needs buffer_view for addr)
-                if region._cuda_pinned and region._buffer_view is not None:
-                    try:
-                        import torch
-
-                        if torch.cuda.is_available():
-                            addr = ctypes.addressof(
-                                ctypes.c_char.from_buffer(region._buffer_view)
-                            )
-                            rc = torch.cuda.cudart().cudaHostUnregister(addr)
-                            rc = int(rc[0]) if isinstance(rc, tuple) else int(rc)
-                            if rc != 0:
-                                _clear_cuda_sticky_error()
-                                logger.warning(
-                                    "cudaHostUnregister failed for region %d: rc=%d",
-                                    region_id,
-                                    rc,
-                                )
-                            region._cuda_pinned = False
-                    except (ImportError, RuntimeError, OSError) as e:
-                        if not isinstance(e, ImportError):
-                            logger.warning(
-                                "cudaHostUnregister failed for region %d: %s",
-                                region_id,
-                                e,
-                            )
+                self._cuda_unpin_region(region)
 
                 if region.is_mapped:
                     region.release()
@@ -289,6 +301,33 @@ class DaxMapper:
             except Exception:
                 logger.error("Error unmapping region %d", region_id, exc_info=True)
                 return False
+
+    @staticmethod
+    def _cuda_unpin_region(region: MappedRegion) -> None:
+        """cudaHostUnregister a region that actually pinned (rc-checked)."""
+        if not (region._cuda_pinned and region._buffer_view is not None):
+            return
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                addr = ctypes.addressof(ctypes.c_char.from_buffer(region._buffer_view))
+                rc = _cuda_rc(torch.cuda.cudart().cudaHostUnregister(addr))
+                if rc != 0:
+                    _clear_cuda_sticky_error()
+                    logger.warning(
+                        "cudaHostUnregister failed for region %d: rc=%d",
+                        region.region_id,
+                        rc,
+                    )
+                region._cuda_pinned = False
+        except (ImportError, RuntimeError, OSError) as e:
+            if not isinstance(e, ImportError):
+                logger.warning(
+                    "cudaHostUnregister failed for region %d: %s",
+                    region.region_id,
+                    e,
+                )
 
     # =========================================================================
     # Query
@@ -327,32 +366,7 @@ class DaxMapper:
                     continue
                 try:
                     # CUDA unpin before munmap (order matters!)
-                    if region._cuda_pinned and region._buffer_view is not None:
-                        try:
-                            import torch
-
-                            if torch.cuda.is_available():
-                                addr = ctypes.addressof(
-                                    ctypes.c_char.from_buffer(region._buffer_view)
-                                )
-                                rc = torch.cuda.cudart().cudaHostUnregister(addr)
-                                rc = int(rc[0]) if isinstance(rc, tuple) else int(rc)
-                                if rc != 0:
-                                    _clear_cuda_sticky_error()
-                                    logger.warning(
-                                        "cudaHostUnregister failed for region "
-                                        "%d: rc=%d",
-                                        rid,
-                                        rc,
-                                    )
-                                region._cuda_pinned = False
-                        except (ImportError, RuntimeError, OSError) as e:
-                            if not isinstance(e, ImportError):
-                                logger.warning(
-                                    "cudaHostUnregister failed for region %d: %s",
-                                    rid,
-                                    e,
-                                )
+                    self._cuda_unpin_region(region)
 
                     if region.is_mapped:
                         region.release()

--- a/maru_handler/memory/mapper.py
+++ b/maru_handler/memory/mapper.py
@@ -25,6 +25,30 @@ _PREFAULT_ENABLED = os.environ.get("MARU_PREFAULT", "1") != "0"
 _PAGE_SIZE = os.sysconf("SC_PAGESIZE") if hasattr(os, "sysconf") else 4096
 
 
+def _clear_cuda_sticky_error() -> None:
+    """Consume CUDA's per-thread sticky error after a failed cudaHostRegister.
+
+    torch's cudart binding does not expose cudaGetLastError, so locate the
+    libcudart torch itself loaded (dlopen of the same path returns the
+    already-loaded instance) and consume the error there.  Without this, the
+    next error-checked CUDA call on this thread — typically an unrelated
+    kernel launch — raises a misattributed "CUDA error: out of memory".
+    """
+    try:
+        path = None
+        with open("/proc/self/maps") as f:
+            for line in f:
+                if "libcudart.so" in line:
+                    path = line.rstrip("\n").split(maxsplit=5)[-1]
+                    break
+        if path:
+            lib = ctypes.CDLL(path)
+            lib.cudaGetLastError.restype = ctypes.c_int
+            lib.cudaGetLastError()
+    except (OSError, IndexError, AttributeError):
+        logger.debug("could not clear CUDA sticky error", exc_info=True)
+
+
 class DaxMapper:
     """Maps shared memory regions via MaruShmClient.
 
@@ -125,13 +149,34 @@ class DaxMapper:
                         ctypes.c_char.from_buffer(region._buffer_view)
                     )
                     t0 = time.monotonic()
-                    torch.cuda.cudart().cudaHostRegister(addr, handle.length, 0)
-                    cuda_pin_ms = (time.monotonic() - t0) * 1000
-                    logger.info(
-                        "CUDA pinned region %d (%d bytes)",
-                        region_id,
-                        handle.length,
+                    rc = torch.cuda.cudart().cudaHostRegister(
+                        addr, handle.length, 0
                     )
+                    cuda_pin_ms = (time.monotonic() - t0) * 1000
+                    rc = int(rc[0]) if isinstance(rc, tuple) else int(rc)
+                    if rc == 0:
+                        region._cuda_pinned = True
+                        logger.info(
+                            "CUDA pinned region %d (%d bytes)",
+                            region_id,
+                            handle.length,
+                        )
+                    else:
+                        # NVIDIA r580+ drivers reject a single registration
+                        # of >= 512 GiB (per-registration page table hits
+                        # the kernel's kvmalloc INT_MAX cap: "NVRM: failed
+                        # to allocate page table"). Clear the per-thread
+                        # sticky error so an unrelated later CUDA call does
+                        # not crash with a misattributed OOM.
+                        _clear_cuda_sticky_error()
+                        logger.warning(
+                            "cudaHostRegister failed for region %d "
+                            "(%d bytes): rc=%d — region stays unpinned, "
+                            "GPU transfers fall back to pageable copies",
+                            region_id,
+                            handle.length,
+                            rc,
+                        )
             except (ImportError, RuntimeError, OSError) as e:
                 if not isinstance(e, ImportError):
                     logger.warning(
@@ -204,7 +249,7 @@ class DaxMapper:
 
             try:
                 # CUDA unpin before munmap (order matters — needs buffer_view for addr)
-                if region._buffer_view is not None:
+                if region._cuda_pinned and region._buffer_view is not None:
                     try:
                         import torch
 
@@ -212,7 +257,17 @@ class DaxMapper:
                             addr = ctypes.addressof(
                                 ctypes.c_char.from_buffer(region._buffer_view)
                             )
-                            torch.cuda.cudart().cudaHostUnregister(addr)
+                            rc = torch.cuda.cudart().cudaHostUnregister(addr)
+                            rc = int(rc[0]) if isinstance(rc, tuple) else int(rc)
+                            if rc != 0:
+                                _clear_cuda_sticky_error()
+                                logger.warning(
+                                    "cudaHostUnregister failed for region "
+                                    "%d: rc=%d",
+                                    region_id,
+                                    rc,
+                                )
+                            region._cuda_pinned = False
                     except (ImportError, RuntimeError, OSError) as e:
                         if not isinstance(e, ImportError):
                             logger.warning(
@@ -275,7 +330,7 @@ class DaxMapper:
                     continue
                 try:
                     # CUDA unpin before munmap (order matters!)
-                    if region._buffer_view is not None:
+                    if region._cuda_pinned and region._buffer_view is not None:
                         try:
                             import torch
 
@@ -283,7 +338,17 @@ class DaxMapper:
                                 addr = ctypes.addressof(
                                     ctypes.c_char.from_buffer(region._buffer_view)
                                 )
-                                torch.cuda.cudart().cudaHostUnregister(addr)
+                                rc = torch.cuda.cudart().cudaHostUnregister(addr)
+                                rc = int(rc[0]) if isinstance(rc, tuple) else int(rc)
+                                if rc != 0:
+                                    _clear_cuda_sticky_error()
+                                    logger.warning(
+                                        "cudaHostUnregister failed for region "
+                                        "%d: rc=%d",
+                                        rid,
+                                        rc,
+                                    )
+                                region._cuda_pinned = False
                         except (ImportError, RuntimeError, OSError) as e:
                             if not isinstance(e, ImportError):
                                 logger.warning(

--- a/maru_handler/memory/mapper.py
+++ b/maru_handler/memory/mapper.py
@@ -149,9 +149,7 @@ class DaxMapper:
                         ctypes.c_char.from_buffer(region._buffer_view)
                     )
                     t0 = time.monotonic()
-                    rc = torch.cuda.cudart().cudaHostRegister(
-                        addr, handle.length, 0
-                    )
+                    rc = torch.cuda.cudart().cudaHostRegister(addr, handle.length, 0)
                     cuda_pin_ms = (time.monotonic() - t0) * 1000
                     rc = int(rc[0]) if isinstance(rc, tuple) else int(rc)
                     if rc == 0:
@@ -262,8 +260,7 @@ class DaxMapper:
                             if rc != 0:
                                 _clear_cuda_sticky_error()
                                 logger.warning(
-                                    "cudaHostUnregister failed for region "
-                                    "%d: rc=%d",
+                                    "cudaHostUnregister failed for region %d: rc=%d",
                                     region_id,
                                     rc,
                                 )

--- a/maru_handler/memory/types.py
+++ b/maru_handler/memory/types.py
@@ -31,6 +31,9 @@ class MappedRegion:
     _mmap_obj: mmap_module.mmap | None = field(default=None, repr=False)
     # memoryview of the entire mmap — created eagerly in __post_init__
     _buffer_view: memoryview | None = field(default=None, repr=False, init=False)
+    # True only when cudaHostRegister actually succeeded (rc == 0), so
+    # unmap/close know whether cudaHostUnregister is needed
+    _cuda_pinned: bool = field(default=False, repr=False, init=False)
 
     def __post_init__(self):
         if self._mmap_obj is not None:

--- a/tests/unit/test_mapper.py
+++ b/tests/unit/test_mapper.py
@@ -189,6 +189,54 @@ class TestDaxMapperCudaPin:
         assert region.is_mapped
 
 
+class TestDaxMapperPinRcCheck:
+    """cudaHostRegister return-code checking (previously ignored)."""
+
+    def test_register_rc_failure_warns_and_skips_unregister(self, monkeypatch):
+        """rc != 0 → warning, region unpinned, no unregister on unmap."""
+        import logging
+
+        import maru_handler.memory.mapper as mapper_mod
+
+        cleared = []
+        monkeypatch.setattr(
+            mapper_mod, "_clear_cuda_sticky_error", lambda: cleared.append(1)
+        )
+
+        mock_torch, mock_cudart = _mock_torch_cuda()
+        mock_cudart.cudaHostRegister.return_value = (2,)  # cudaErrorMemoryAllocation
+
+        mapper = DaxMapper()
+        handle = _make_handle(1, 4096)
+
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            with patch.object(
+                logging.getLogger("maru_handler.memory.mapper"), "warning"
+            ) as mock_warning:
+                region = mapper.map_region(handle)
+            mapper.unmap_region(1)
+
+        assert region._cuda_pinned is False
+        assert cleared == [1]
+        assert mock_warning.called
+        assert "cudaHostRegister failed" in mock_warning.call_args[0][0]
+        mock_cudart.cudaHostUnregister.assert_not_called()
+
+    def test_register_rc_success_sets_pinned_and_unregisters(self):
+        """rc == 0 → pinned flag set, unmap unregisters once."""
+        mock_torch, mock_cudart = _mock_torch_cuda()
+
+        mapper = DaxMapper()
+        handle = _make_handle(1, 4096)
+
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            region = mapper.map_region(handle)
+            assert region._cuda_pinned is True
+            mapper.unmap_region(1)
+
+        mock_cudart.cudaHostUnregister.assert_called_once()
+
+
 class TestDaxMapperErrorPaths:
     """Test error paths for 100% coverage."""
 

--- a/tests/unit/test_mapper.py
+++ b/tests/unit/test_mapper.py
@@ -236,6 +236,70 @@ class TestDaxMapperPinRcCheck:
 
         mock_cudart.cudaHostUnregister.assert_called_once()
 
+    def test_unregister_rc_failure_warns(self, monkeypatch):
+        """Non-zero cudaHostUnregister rc → warning + sticky error cleared."""
+        import logging
+
+        import maru_handler.memory.mapper as mapper_mod
+
+        cleared = []
+        monkeypatch.setattr(
+            mapper_mod, "_clear_cuda_sticky_error", lambda: cleared.append(1)
+        )
+
+        mock_torch, mock_cudart = _mock_torch_cuda()
+        mock_cudart.cudaHostUnregister.return_value = (1,)  # cudaErrorInvalidValue
+
+        mapper = DaxMapper()
+        handle = _make_handle(1, 4096)
+
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            mapper.map_region(handle)
+            with patch.object(
+                logging.getLogger("maru_handler.memory.mapper"), "warning"
+            ) as mock_warning:
+                assert mapper.unmap_region(1) is True
+
+        assert cleared == [1]
+        assert mock_warning.called
+        assert "cudaHostUnregister failed" in mock_warning.call_args[0][0]
+
+
+class TestFindLibcudartPaths:
+    """_find_libcudart_paths: /proc/self/maps parsing."""
+
+    def _paths_from(self, maps_content, monkeypatch):
+        from io import StringIO
+        from unittest.mock import patch as _patch
+
+        import maru_handler.memory.mapper as mapper_mod
+
+        with _patch("builtins.open", return_value=StringIO(maps_content)):
+            return mapper_mod._find_libcudart_paths()
+
+    def test_matches_plain_and_hashed_names(self, monkeypatch):
+        maps = (
+            "7f00-7f01 r-xp 0 08:01 1 /usr/lib/libcudart.so.12\n"
+            "7f02-7f03 r-xp 0 08:01 2 "
+            "/venv/torch/lib/libcudart-9335f6a2.so.12\n"
+            "7f04-7f05 r-xp 0 08:01 3 /usr/lib/libc.so.6\n"
+        )
+        assert self._paths_from(maps, monkeypatch) == [
+            "/usr/lib/libcudart.so.12",
+            "/venv/torch/lib/libcudart-9335f6a2.so.12",
+        ]
+
+    def test_strips_deleted_suffix_and_dedupes(self, monkeypatch):
+        maps = (
+            "7f00-7f01 r-xp 0 08:01 1 /venv/libcudart.so.12 (deleted)\n"
+            "7f02-7f03 rw-p 0 08:01 1 /venv/libcudart.so.12 (deleted)\n"
+        )
+        assert self._paths_from(maps, monkeypatch) == ["/venv/libcudart.so.12"]
+
+    def test_ignores_anonymous_mappings(self, monkeypatch):
+        maps = "7f00-7f01 rw-p 0 00:00 0\n7f02-7f03 rw-p 0 00:00 0 [heap]\n"
+        assert self._paths_from(maps, monkeypatch) == []
+
 
 class TestDaxMapperErrorPaths:
     """Test error paths for 100% coverage."""


### PR DESCRIPTION
## Problem

`DaxMapper.map_region()` ignores the return code of `torch.cuda.cudart().cudaHostRegister(...)` — torch's cudart binding reports errors via `cudaError_t`, it does not raise. Two consequences:

1. **False success**: a failed pin still logs `CUDA pinned region ...`, so the region silently runs unpinned (pageable-copy GPU transfers).
2. **Misattributed crash**: the failed call latches CUDA's per-thread sticky error, and the next error-checked CUDA call on that thread — typically an unrelated kernel launch — raises `torch.AcceleratorError: CUDA error: out of memory`. Reproduced with `pool_size: "520"`: vLLM EngineCore dies at startup in flashinfer autotune (`sm.fill_`), pointing at an innocent op.

The concrete trigger today is the NVIDIA r580+ driver's per-registration limit: a single `cudaHostRegister` of >= 2^39 bytes (512 GiB) fails with `cudaErrorMemoryAllocation` because the driver's per-page bookkeeping table (16 B / 4 KiB page, one flat `kvzalloc`) hits the kernel's `INT_MAX` cap — `NVRM: failed to allocate page table` in dmesg. Confirmed on two hosts (580.126.20, 580.159.03); drivers <= 575.x are unaffected.

## Change (minimal, no behavior change on the success path)

- Check the `cudaHostRegister` return code. Success: same log as before, and the region is marked pinned. Failure: consume the sticky error via the process's own `libcudart` (`cudaGetLastError`) and log a warning — the region stays usable, GPU transfers fall back to pageable copies, and nothing crashes later.
- `unmap_region()`/`close()` only call `cudaHostUnregister` for regions that actually pinned, and check that return code too.

## Verification

- 2 new unit tests (rc failure -> warning + no unregister; rc success -> pinned + single unregister); mapper suite 30 passed.
- Diagnosis aid: with this branch, an oversized pool logs `cudaHostRegister failed for region N (...): rc=2 — region stays unpinned` instead of crashing with a fake OOM.

## Upstream driver fix

The underlying >= 512 GiB failure is an r580 driver regression, and the fix (vzalloc fallback for the oversized page table) is already pending upstream: NVIDIA/open-gpu-kernel-modules#1234 (we reproduced the bug on two hosts and confirmed the same fix compiles against 580.126.20; see the supporting comment there). Once that lands and a fixed driver ships, large single-call registrations simply work again.

So the plan is: merge this rc-check fix (worth having regardless of the driver — a failed pin should warn instead of lying in the logs and crashing an unrelated kernel launch later), and wait for the driver fix for the >= 512 GiB case itself. Until a fixed driver ships, oversized pools run unpinned with a clear warning (pageable-copy performance). The chunked-registration workaround was #64, now closed; the branch is kept in case the upstream fix stalls.

