### PR TITLE
fix: flush CPU cache lines in device UUID header read/write paths

### DIFF
--- a/maru_resource_manager/src/device_header.cpp
+++ b/maru_resource_manager/src/device_header.cpp
@@ -9,7 +9,41 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#if defined(__x86_64__) || defined(__i386__)
+#include <emmintrin.h>
+#endif
+
 namespace maru {
+
+namespace {
+
+constexpr uintptr_t kCacheLineSize = 64;
+
+// Write back and invalidate the CPU cache lines covering [p, p+n).
+//
+// DEV_DAX mappings are write-back cached, and msync() does not touch CPU
+// caches there (device-dax has no page cache and no fsync op). CXL 2.x has
+// no cross-host cache coherence, so a header written here would otherwise
+// sit in this host's cache, invisible to other hosts sharing the device,
+// and a header read here would leave a copy that goes stale when another
+// host rewrites it. clflush covers both: it writes back dirty lines
+// (writer side) and invalidates clean copies (reader side); mfence orders
+// it against the surrounding loads and stores.
+void flushCacheRange(const void *p, size_t n) {
+#if defined(__x86_64__) || defined(__i386__)
+    const uintptr_t addr = reinterpret_cast<uintptr_t>(p);
+    const uintptr_t end = addr + n;
+    for (uintptr_t line = addr & ~(kCacheLineSize - 1); line < end;
+         line += kCacheLineSize)
+        _mm_clflush(reinterpret_cast<const void *>(line));
+    _mm_mfence();
+#else
+    (void)p;
+    (void)n;
+#endif
+}
+
+} // namespace
 
 int readDeviceHeader(const std::string &devPath, DeviceHeader &out,
                      uint64_t mapSize) {
@@ -23,6 +57,9 @@ int readDeviceHeader(const std::string &devPath, DeviceHeader &out,
     if (ptr == MAP_FAILED)
         return -err;
 
+    // Drop any locally cached copy first so the read comes from the device,
+    // not from a line another host may have made stale.
+    flushCacheRange(ptr, sizeof(out));
     std::memcpy(&out, ptr, sizeof(out));
     ::munmap(ptr, mapSize);
 
@@ -46,6 +83,10 @@ int writeDeviceHeader(const std::string &devPath, const DeviceHeader &hdr,
         return -err;
 
     std::memcpy(ptr, &hdr, sizeof(hdr));
+    // Push the store to the device; on DEV_DAX msync alone leaves it in the
+    // CPU cache where other hosts cannot see it.
+    flushCacheRange(ptr, sizeof(hdr));
+    // Best effort, for regular-file backing (tests); DEV_DAX rejects msync.
     ::msync(ptr, sizeof(hdr), MS_SYNC);
     ::munmap(ptr, mapSize);
     return 0;

--- a/maru_resource_manager/src/device_header.cpp
+++ b/maru_resource_manager/src/device_header.cpp
@@ -28,7 +28,9 @@ constexpr uintptr_t kCacheLineSize = 64;
 // and a header read here would leave a copy that goes stale when another
 // host rewrites it. clflush covers both: it writes back dirty lines
 // (writer side) and invalidates clean copies (reader side); mfence orders
-// it against the surrounding loads and stores.
+// it against the surrounding loads and stores. clflush is preferred over
+// clflushopt/clwb: available on every x86-64 without CPUID dispatch, and
+// the header is a single cache line so flush throughput is irrelevant.
 void flushCacheRange(const void *p, size_t n) {
 #if defined(__x86_64__) || defined(__i386__)
     const uintptr_t addr = reinterpret_cast<uintptr_t>(p);

--- a/maru_shm/_cxl_flush.c
+++ b/maru_shm/_cxl_flush.c
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 XCENA Inc.
+ *
+ * CPU cache-line flush helper for CXL shared memory (DEV_DAX).
+ *
+ * DEV_DAX mappings are write-back cached, and msync()/mmap.flush() does not
+ * touch CPU caches there (device-dax has no page cache and no fsync op).
+ * CXL 2.x has no cross-host cache coherence, so data written by CPU store
+ * would otherwise sit in this host's cache, invisible to other hosts sharing
+ * the device, and a CPU read leaves a copy that goes stale when another host
+ * rewrites the same range. clflush covers both: it writes back dirty lines
+ * (writer side) and invalidates clean copies (reader side); mfence orders it
+ * against the surrounding loads and stores.
+ */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <stdint.h>
+
+#if defined(__x86_64__) || defined(__i386__)
+#include <emmintrin.h>
+#define MARU_HAVE_CLFLUSH 1
+#else
+#define MARU_HAVE_CLFLUSH 0
+#endif
+
+#define MARU_CACHE_LINE 64
+
+static PyObject *flush_range(PyObject *self, PyObject *args) {
+    Py_buffer view;
+    Py_ssize_t offset = 0;
+    Py_ssize_t length = -1;
+
+    (void)self;
+
+    if (!PyArg_ParseTuple(args, "y*|nn:flush_range", &view, &offset, &length))
+        return NULL;
+
+    if (length < 0)
+        length = view.len - offset;
+
+    if (offset < 0 || length < 0 || offset > view.len - length) {
+        PyBuffer_Release(&view);
+        PyErr_SetString(PyExc_ValueError,
+                        "flush_range: offset/length out of bounds");
+        return NULL;
+    }
+
+#if MARU_HAVE_CLFLUSH
+    {
+        uintptr_t addr = (uintptr_t)view.buf + (uintptr_t)offset;
+        uintptr_t end = addr + (uintptr_t)length;
+        uintptr_t line = addr & ~(uintptr_t)(MARU_CACHE_LINE - 1);
+        for (; line < end; line += MARU_CACHE_LINE)
+            _mm_clflush((const void *)line);
+        _mm_mfence();
+    }
+#endif
+
+    PyBuffer_Release(&view);
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef cxl_flush_methods[] = {
+    {"flush_range", flush_range, METH_VARARGS,
+     "flush_range(buffer, offset=0, length=-1)\n\n"
+     "Write back and invalidate the CPU cache lines covering\n"
+     "buffer[offset:offset+length] (clflush per 64B line, then mfence).\n"
+     "No-op on architectures without clflush (see HAVE_CLFLUSH)."},
+    {NULL, NULL, 0, NULL},
+};
+
+static struct PyModuleDef cxl_flush_module = {
+    PyModuleDef_HEAD_INIT,
+    "_cxl_flush",
+    "CPU cache flush for CXL DEV_DAX mappings.",
+    -1,
+    cxl_flush_methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+};
+
+PyMODINIT_FUNC PyInit__cxl_flush(void) {
+    PyObject *m = PyModule_Create(&cxl_flush_module);
+    if (m == NULL)
+        return NULL;
+    if (PyModule_AddIntConstant(m, "HAVE_CLFLUSH", MARU_HAVE_CLFLUSH) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
+    return m;
+}

--- a/maru_shm/_cxl_flush.c
+++ b/maru_shm/_cxl_flush.c
@@ -10,7 +10,10 @@
  * the device, and a CPU read leaves a copy that goes stale when another host
  * rewrites the same range. clflush covers both: it writes back dirty lines
  * (writer side) and invalidates clean copies (reader side); mfence orders it
- * against the surrounding loads and stores.
+ * against the surrounding loads and stores. clflush is preferred over
+ * clflushopt/clwb: available on every x86-64 without CPUID dispatch, and the
+ * flushed ranges are tiny (header = one cache line) so throughput is
+ * irrelevant.
  */
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>

--- a/maru_shm/device_scanner.py
+++ b/maru_shm/device_scanner.py
@@ -7,6 +7,11 @@ import mmap
 import os
 import struct
 
+try:
+    from maru_shm._cxl_flush import flush_range as _flush_range
+except ImportError:  # extension not built (no compiler at install time)
+    _flush_range = None
+
 logger = logging.getLogger(__name__)
 
 # Must match C++ device_header.h
@@ -14,6 +19,36 @@ _HEADER_MAGIC = b"MARUDEV\x00"
 _HEADER_SIZE = 32
 _HEADER_FORMAT = "<8sI16sI"  # magic(8) + version(u32) + uuid(16) + reserved(u32)
 _DEFAULT_MAP_SIZE = 2 * 1024 * 1024  # 2 MiB fallback
+
+_flush_warned = False
+
+
+def _flush_header_lines(mm: mmap.mmap) -> None:
+    """Write back / invalidate the CPU cache lines holding the device header.
+
+    DEV_DAX mappings are write-back cached and msync()/mm.flush() does not
+    touch CPU caches there, while CXL 2.x has no cross-host cache coherence.
+    Without an explicit clflush, a written header sits in this host's cache
+    (invisible to other hosts sharing the device) and a read leaves a copy
+    that goes stale when another host rewrites the header.
+    """
+    global _flush_warned
+    if _flush_range is not None:
+        _flush_range(mm, 0, _HEADER_SIZE)
+    elif not _flush_warned:
+        _flush_warned = True
+        logger.warning(
+            "maru_shm._cxl_flush extension not available; skipping device "
+            "header cache flush (multi-host UUID visibility not guaranteed)"
+        )
+
+
+def _msync_best_effort(mm: mmap.mmap) -> None:
+    """Flush for regular-file backing (tests); DEV_DAX may reject msync."""
+    try:
+        mm.flush()
+    except OSError:
+        logger.debug("mm.flush() failed (expected on DEV_DAX)", exc_info=True)
 
 
 def _get_dax_align(dax_path: str) -> int:
@@ -42,6 +77,9 @@ def read_device_uuid(dax_path: str) -> str | None:
                 map_size = file_size
             mm = mmap.mmap(fd, map_size, mmap.MAP_SHARED, mmap.PROT_READ)
             try:
+                # Drop any locally cached copy first so the read comes from
+                # the device, not from a line another host made stale.
+                _flush_header_lines(mm)
                 data = mm[:_HEADER_SIZE]
             finally:
                 mm.close()
@@ -120,7 +158,10 @@ def write_device_header(dax_path: str, uuid_bytes: bytes | None = None) -> str:
         mm = mmap.mmap(fd, map_size, mmap.MAP_SHARED, mmap.PROT_WRITE)
         try:
             mm[:_HEADER_SIZE] = header
-            mm.flush()
+            # Push the store to the device; msync alone leaves it in the CPU
+            # cache on DEV_DAX, where other hosts cannot see it.
+            _flush_header_lines(mm)
+            _msync_best_effort(mm)
         finally:
             mm.close()
     finally:
@@ -140,7 +181,8 @@ def clear_device_header(dax_path: str) -> None:
         mm = mmap.mmap(fd, map_size, mmap.MAP_SHARED, mmap.PROT_WRITE)
         try:
             mm[:_HEADER_SIZE] = b"\x00" * _HEADER_SIZE
-            mm.flush()
+            _flush_header_lines(mm)
+            _msync_best_effort(mm)
         finally:
             mm.close()
     finally:

--- a/maru_shm/device_scanner.py
+++ b/maru_shm/device_scanner.py
@@ -8,9 +8,11 @@ import os
 import struct
 
 try:
+    from maru_shm._cxl_flush import HAVE_CLFLUSH as _HAVE_CLFLUSH
     from maru_shm._cxl_flush import flush_range as _flush_range
 except ImportError:  # extension not built (no compiler at install time)
     _flush_range = None
+    _HAVE_CLFLUSH = 0
 
 logger = logging.getLogger(__name__)
 
@@ -33,13 +35,14 @@ def _flush_header_lines(mm: mmap.mmap) -> None:
     that goes stale when another host rewrites the header.
     """
     global _flush_warned
-    if _flush_range is not None:
+    if _flush_range is not None and _HAVE_CLFLUSH:
         _flush_range(mm, 0, _HEADER_SIZE)
     elif not _flush_warned:
         _flush_warned = True
         logger.warning(
-            "maru_shm._cxl_flush extension not available; skipping device "
-            "header cache flush (multi-host UUID visibility not guaranteed)"
+            "device header cache flush unavailable (extension not built, or "
+            "no clflush on this architecture); multi-host UUID visibility "
+            "not guaranteed"
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,15 @@
 """Setup script for Maru."""
 
-from setuptools import setup
+from setuptools import Extension, setup
 
-setup()
+setup(
+    ext_modules=[
+        Extension(
+            "maru_shm._cxl_flush",
+            sources=["maru_shm/_cxl_flush.c"],
+            # Best effort: without the extension, device_scanner falls back
+            # to a no-op flush and logs a warning (single-host still works).
+            optional=True,
+        )
+    ]
+)

--- a/tests/unit/test_device_scanner.py
+++ b/tests/unit/test_device_scanner.py
@@ -172,6 +172,21 @@ class TestCacheFlushFallback:
 
         assert mock_logger.warning.call_count == 1
 
+    def test_no_clflush_arch_warns_once(self, tmp_path):
+        """Extension built but HAVE_CLFLUSH=0 (non-x86): same one-time warning."""
+        dev = tmp_path / "dax0.0"
+        dev.write_bytes(_make_header())
+
+        with (
+            mock.patch("maru_shm.device_scanner._HAVE_CLFLUSH", 0),
+            mock.patch("maru_shm.device_scanner._flush_warned", False),
+            mock.patch("maru_shm.device_scanner.logger") as mock_logger,
+        ):
+            read_device_uuid(str(dev))
+            read_device_uuid(str(dev))
+
+        assert mock_logger.warning.call_count == 1
+
     def test_msync_oserror_is_swallowed(self):
         """DEV_DAX may reject msync (EINVAL) — the helper must not raise."""
         from maru_shm.device_scanner import _msync_best_effort

--- a/tests/unit/test_device_scanner.py
+++ b/tests/unit/test_device_scanner.py
@@ -2,16 +2,27 @@
 # Copyright 2026 XCENA Inc.
 """Unit tests for maru_shm.device_scanner."""
 
+import mmap
+import os
 import struct
 from unittest import mock
+
+import pytest
 
 from maru_shm.device_scanner import (
     _HEADER_FORMAT,
     _HEADER_MAGIC,
+    clear_device_header,
     read_device_uuid,
     scan_dax_devices,
     uuid_to_string,
+    write_device_header,
 )
+
+try:
+    from maru_shm import _cxl_flush
+except ImportError:  # extension not built
+    _cxl_flush = None
 
 
 # Helper to build a valid 32-byte header
@@ -129,3 +140,84 @@ class TestScanDaxDevices:
             mock.patch("maru_shm.device_scanner.os.path.exists", return_value=False),
         ):
             assert scan_dax_devices() == []
+
+
+# ── CPU cache flush (multi-host visibility) ─────────────────────────────────
+
+
+class TestCacheFlushFallback:
+    """Header R/W must keep working when the _cxl_flush extension is absent."""
+
+    def test_write_read_clear_without_extension(self, tmp_path):
+        dev = tmp_path / "dax0.0"
+        dev.write_bytes(b"\x00" * 4096)
+
+        with mock.patch("maru_shm.device_scanner._flush_range", None):
+            uuid_str = write_device_header(str(dev))
+            assert read_device_uuid(str(dev)) == uuid_str
+            clear_device_header(str(dev))
+            assert read_device_uuid(str(dev)) is None
+
+    def test_fallback_warns_once(self, tmp_path):
+        dev = tmp_path / "dax0.0"
+        dev.write_bytes(_make_header())
+
+        with (
+            mock.patch("maru_shm.device_scanner._flush_range", None),
+            mock.patch("maru_shm.device_scanner._flush_warned", False),
+            mock.patch("maru_shm.device_scanner.logger") as mock_logger,
+        ):
+            read_device_uuid(str(dev))
+            read_device_uuid(str(dev))
+
+        assert mock_logger.warning.call_count == 1
+
+    def test_msync_oserror_is_swallowed(self):
+        """DEV_DAX may reject msync (EINVAL) — the helper must not raise."""
+        from maru_shm.device_scanner import _msync_best_effort
+
+        class FakeMM:
+            def flush(self):
+                raise OSError(22, "Invalid argument")
+
+        _msync_best_effort(FakeMM())
+
+
+@pytest.mark.skipif(_cxl_flush is None, reason="_cxl_flush extension not built")
+class TestFlushRangeExtension:
+    def test_flush_mmap_buffer(self, tmp_path):
+        dev = tmp_path / "dax0.0"
+        dev.write_bytes(b"\x00" * 4096)
+        fd = os.open(str(dev), os.O_RDWR)
+        try:
+            mm = mmap.mmap(fd, 4096, mmap.MAP_SHARED, mmap.PROT_WRITE)
+            try:
+                mm[:4] = b"abcd"
+                _cxl_flush.flush_range(mm, 0, 32)
+                assert mm[:4] == b"abcd"
+            finally:
+                mm.close()
+        finally:
+            os.close(fd)
+
+    def test_flush_readonly_buffer_defaults(self):
+        # Whole buffer, default offset/length; read-only objects are accepted
+        _cxl_flush.flush_range(b"x" * 128)
+
+    def test_flush_bytearray_with_offset(self):
+        _cxl_flush.flush_range(bytearray(256), 64, 128)
+
+    def test_zero_length_is_noop(self):
+        _cxl_flush.flush_range(b"x" * 64, 0, 0)
+
+    def test_negative_offset_rejected(self):
+        with pytest.raises(ValueError):
+            _cxl_flush.flush_range(b"x" * 64, -1, 8)
+
+    def test_offset_past_end_rejected(self):
+        with pytest.raises(ValueError):
+            _cxl_flush.flush_range(b"x" * 64, 65)
+
+    def test_length_past_end_rejected(self):
+        with pytest.raises(ValueError):
+            _cxl_flush.flush_range(b"x" * 64, 0, 128)


### PR DESCRIPTION
## 🤔 Background & Motivation (Why)
- The device UUID header is read/written with plain CPU load/store through a DEV_DAX mmap. CPU stores stay in the write-back cache, and `msync()` does not flush CPU caches on DEV_DAX (no page cache, no fsync op).
- CXL 2.x shared memory has no cross-host cache coherence, so on multi-host setups a freshly written header is invisible to other hosts — both RMs auto-initialize the same device with different UUIDs (identity split-brain) — and a header cached by an earlier read goes stale when another host rewrites it.
- Multi-host simulation (HDM window aliasing) measured the CPU-store path stale 0/50 on every platform, corrected only by `clflush`+fence.

## 🏗️ Design Changes
- Behavioral: header **writes** now end with `clflush`+`mfence` (write-back to device), header **reads** now start with `clflush`+`mfence` (invalidate any stale local copy). Encapsulated inside the header R/W functions — no caller changes.
- Dependency: new optional C extension `maru_shm._cxl_flush`; if not built, Python falls back to a no-op with a one-time warning (single-host behavior unchanged).

```mermaid
sequenceDiagram
    participant A as Host A (RM / CLI)
    participant C as Host A CPU cache
    participant D as CXL device
    participant B as Host B (scanner)

    rect rgb(255, 235, 235)
    Note over A,B: Before — header trapped in Host A's cache
    A->>C: store header (mmap memcpy)
    C--xD: write-back deferred indefinitely (msync = no-op on DEV_DAX)
    B->>D: read header
    D-->>B: zeros → "no header" → B re-inits with a different UUID (split-brain)
    end

    rect rgb(235, 255, 235)
    Note over A,B: After — explicit cache-line flush
    A->>C: store header (mmap memcpy)
    A->>C: clflush + mfence
    C->>D: header line written back
    B->>B: clflush (drop stale local copy)
    B->>D: read header
    D-->>B: valid magic + UUID
    end
```

## 📝 Implementation Details
- `maru_resource_manager/src/device_header.cpp`: `flushCacheRange()` (`clflush` per 64B line + `mfence`; x86-only, no-op elsewhere) — called after the store in `writeDeviceHeader()` and before the load in `readDeviceHeader()`. `msync` kept as best effort for regular-file backing (tests).
- `maru_shm/_cxl_flush.c` (new): `flush_range(buffer, offset=0, length=-1)` via buffer protocol with bounds checking; `HAVE_CLFLUSH` constant. Registered in `setup.py` as an optional extension.
- `maru_shm/device_scanner.py`: flush applied in `write_device_header` / `clear_device_header` (after store) and `read_device_uuid` (before load). `mm.flush()` wrapped in try/except — DEV_DAX may reject msync with EINVAL.

## ✅ Tests
- [x] Unit tests — 10 new in `tests/unit/test_device_scanner.py` (extension-missing fallback roundtrip, one-time warning, msync error swallow, `flush_range` bounds); C++ `maru_rm_tests` 16/16
- [x] Integration tests — `tests/integration/test_daxmapping_flow.py` passes
- [x] Manual tests — cross-host visibility verified on the multi-host window-alias harness: control 50/50, aliased writer 50/50 / reader 50/50, RM auto-init header identical through both windows

## 🔗 Related Issues (optional)
-

## 📦 Release Note (for auto-generation / write in English)
### NEW
-
### CHANGED
-
### FIXED
- RM: Device UUID header reads/writes now flush CPU cache lines so the header is visible and fresh across hosts sharing a CXL device (multi-host UUID resolution).
### IMPORTANT NOTES
-