### PR TITLE
fix(maru_vllm): adapt LMCache kernel integration to relocated KV-type enums

### DIFF
--- a/maru_vllm/connector.py
+++ b/maru_vllm/connector.py
@@ -2226,7 +2226,15 @@ class MaruWorkerConnector:
         if obj_bytes is None or run_view.nbytes < run_chunks * obj_bytes:
             return False
         ops = self._lmc_ops
-        kv_format = getattr(ops.EngineKVFormat, layout.format_name, None)
+        # getattr on ops itself as well: newer LMCache builds expose c_ops via
+        # a device-ops shim that has no EngineKVFormat at all, and only the
+        # inner lookup was guarded before — the shim raised out of the load path.
+        kv_format_enum = getattr(ops, "EngineKVFormat", None)
+        kv_format = (
+            getattr(kv_format_enum, layout.format_name, None)
+            if kv_format_enum is not None
+            else None
+        )
         if kv_format is None:
             logger.warning(
                 "Maru fused load: kernel has no format %s; using memcpy fallback",
@@ -2426,9 +2434,16 @@ class MaruWorkerConnector:
         for _, kv_cache_layer, true_idx in layers:
             ptrs[true_idx] = kv_cache_layer.data_ptr()
         ops = self._lmc_ops
-        # An older c_ops build may not carry every format; take the per-layer
-        # fallback rather than raising out of the load path.
-        kv_format = getattr(ops.EngineKVFormat, layout.format_name, None)
+        # An older c_ops build may not carry every format — and newer LMCache
+        # builds expose c_ops via a device-ops shim with no EngineKVFormat at
+        # all — so guard both lookups and take the per-layer fallback rather
+        # than raising out of the load path.
+        kv_format_enum = getattr(ops, "EngineKVFormat", None)
+        kv_format = (
+            getattr(kv_format_enum, layout.format_name, None)
+            if kv_format_enum is not None
+            else None
+        )
         if kv_format is None:
             logger.warning(
                 "Maru packed load: kernel has no format %s; using per-layer "

--- a/maru_vllm/connector.py
+++ b/maru_vllm/connector.py
@@ -336,6 +336,13 @@ class MaruKVConnector(KVConnectorBase_V1):
             the CXL pages directly (LMCache single_layer_kv_transfer).
             Requires maru_enable_async_loading and the Flash KV layout;
             falls back to memcpy otherwise (default: false)
+        maru_use_lmcache_kernels: bool - Borrow LMCache's compiled transfer
+            kernels (multi_layer/single_layer_kv_transfer) for the packed
+            GPU<->CXL copies when the lmcache package provides them. The
+            KV-format/transfer enums are resolved from lmcache.c_ops or,
+            on newer LMCache, from lmcache.lmcache_native. Set false to
+            force the pure-torch per-layer paths — for benchmarking the
+            fallback or isolating lmcache issues (default: true)
         maru_use_layerwise: bool - Store one CXL object per (chunk, layer)
             (True) or one packed object per chunk holding all layers (False,
             default — mirrors LMCache use_layerwise=False). Packed cuts
@@ -954,6 +961,48 @@ class MaruSchedulerConnector:
 # ============================================================================
 
 
+def _resolve_lmc_ops() -> Any | None:
+    """Bundle lmcache's transfer kernels and KV-type enums into one namespace.
+
+    Older LMCache builds (and the xcena fork) expose everything on the
+    compiled ``lmcache.c_ops`` module. Newer upstream builds route
+    ``lmcache.c_ops`` through a device-ops shim that carries the kernels but
+    not the ``EngineKVFormat`` / ``TransferDirection`` enums, which moved into
+    the ``lmcache.lmcache_native`` extension. Resolve whichever combination is
+    present and return a namespace with the legacy ``ops.<name>`` shape so
+    call sites work against either generation. Returns None when the kernels
+    or the enums cannot be found (callers take the per-layer fallback).
+    """
+    from types import SimpleNamespace
+
+    try:
+        import lmcache.c_ops as lmc_ops
+    except ImportError:
+        return None
+    multi = getattr(lmc_ops, "multi_layer_kv_transfer", None)
+    single = getattr(lmc_ops, "single_layer_kv_transfer", None)
+    if multi is None or single is None:
+        return None
+    kv_format = getattr(lmc_ops, "EngineKVFormat", None)
+    direction = getattr(lmc_ops, "TransferDirection", None)
+    if kv_format is None or direction is None:
+        try:
+            from lmcache.lmcache_native import (  # type: ignore[import-not-found]
+                EngineKVFormat,
+                TransferDirection,
+            )
+
+            kv_format, direction = EngineKVFormat, TransferDirection
+        except ImportError:
+            return None
+    return SimpleNamespace(
+        multi_layer_kv_transfer=multi,
+        single_layer_kv_transfer=single,
+        EngineKVFormat=kv_format,
+        TransferDirection=direction,
+    )
+
+
 class MaruWorkerConnector:
     """Worker-side: performs GPU <-> CXL data transfers in chunk granularity."""
 
@@ -987,6 +1036,10 @@ class MaruWorkerConnector:
         # recognized, which keeps every caller on its existing fallback.
         self._kv_layout: KVLayout | None = None
         self._async_loading = bool(extra_config.get("maru_enable_async_loading", False))
+        # Gate for borrowing LMCache's compiled transfer kernels. False forces
+        # the pure-torch per-layer paths even when lmcache is installed —
+        # useful for benchmarking the fallback or isolating lmcache issues.
+        self._use_lmc_kernels = bool(extra_config.get("maru_use_lmcache_kernels", True))
         self._load_stream: torch.cuda.Stream | None = None
         self._load_stream_device: torch.device | None = None
         self._layer_load_events: dict[str, torch.cuda.Event] = {}
@@ -2144,23 +2197,28 @@ class MaruWorkerConnector:
         return True
 
     def _ensure_fused_ops(self) -> bool:
-        """Resolve ``lmcache.c_ops`` lazily; disable fused load if absent."""
+        """Resolve the lmcache kernels/enums lazily; disable fused load if absent."""
         if not self._fused_load:
             return False
-        if self._lmc_ops is not None:
-            return True
-        try:
-            import lmcache.c_ops as lmc_ops
-
-            self._lmc_ops = lmc_ops
-            return True
-        except ImportError:
+        if not self._use_lmc_kernels:
             logger.warning(
-                "maru_enable_fused_load: lmcache.c_ops unavailable; "
+                "maru_enable_fused_load requires maru_use_lmcache_kernels; "
                 "using memcpy+inject path"
             )
             self._fused_load = False
             return False
+        if self._lmc_ops is not None:
+            return True
+        resolved = _resolve_lmc_ops()
+        if resolved is None:
+            logger.warning(
+                "maru_enable_fused_load: lmcache kernels/KV-type enums "
+                "unavailable; using memcpy+inject path"
+            )
+            self._fused_load = False
+            return False
+        self._lmc_ops = resolved
+        return True
 
     def _use_fused_load(self, attn_metadata: Any, layer_name: str) -> bool:
         """Fused load applies only to the Flash paged-KV layout.
@@ -2412,18 +2470,18 @@ class MaruWorkerConnector:
         )
         if isinstance(layer_meta, (MLACommonMetadata, TritonAttentionMetadata)):
             return None
-        # Resolve lmcache.c_ops (independent of maru_enable_fused_load).
+        if not self._use_lmc_kernels:
+            return None
+        # Resolve the lmcache kernels/enums (independent of maru_enable_fused_load).
         if self._lmc_ops is None:
-            try:
-                import lmcache.c_ops as lmc_ops
-
-                self._lmc_ops = lmc_ops
-            except ImportError:
+            resolved = _resolve_lmc_ops()
+            if resolved is None:
                 logger.warning(
-                    "Maru packed load: lmcache.c_ops unavailable; using "
-                    "per-layer inject fallback"
+                    "Maru packed load: lmcache kernels/KV-type enums "
+                    "unavailable; using per-layer inject fallback"
                 )
                 return None
+            self._lmc_ops = resolved
         # Dimensions and format come from one layout, so they cannot disagree.
         # The kernel takes raw pointers, so torch would not catch it if they did.
         block_size = layout.block_size

--- a/tests/unit/test_vllm_connector.py
+++ b/tests/unit/test_vllm_connector.py
@@ -1951,6 +1951,116 @@ class TestWriteBehindStoreLifecycle:
 # =============================================================================
 
 
+class TestResolveLmcOps:
+    """_resolve_lmc_ops must bundle kernels+enums across LMCache generations:
+    old builds carry everything on ``lmcache.c_ops``; newer upstream routes
+    c_ops through a device-ops shim (kernels only) and relocates the enums
+    into ``lmcache.lmcache_native``."""
+
+    def _fake_c_ops(self, with_enums):
+        import types as _types
+
+        mod = _types.ModuleType("lmcache.c_ops")
+        mod.multi_layer_kv_transfer = lambda *a, **k: None
+        mod.single_layer_kv_transfer = lambda *a, **k: None
+        if with_enums:
+            mod.EngineKVFormat = SimpleNamespace(NL_X_TWO_NB_BS_NH_HS="F")
+            mod.TransferDirection = SimpleNamespace(H2D="H2D", D2H="D2H")
+        return mod
+
+    def _fake_native(self):
+        import types as _types
+
+        mod = _types.ModuleType("lmcache.lmcache_native")
+        mod.EngineKVFormat = SimpleNamespace(NL_X_TWO_NB_BS_NH_HS="F")
+        mod.TransferDirection = SimpleNamespace(H2D="H2D", D2H="D2H")
+        return mod
+
+    def test_old_style_everything_on_c_ops(self, monkeypatch):
+        import sys
+
+        from maru_vllm.connector import _resolve_lmc_ops
+
+        monkeypatch.setitem(sys.modules, "lmcache.c_ops", self._fake_c_ops(True))
+        monkeypatch.setitem(sys.modules, "lmcache.lmcache_native", None)
+        ops = _resolve_lmc_ops()
+        assert ops is not None
+        assert ops.TransferDirection.H2D == "H2D"
+
+    def test_new_style_enums_from_lmcache_native(self, monkeypatch):
+        import sys
+
+        from maru_vllm.connector import _resolve_lmc_ops
+
+        monkeypatch.setitem(sys.modules, "lmcache.c_ops", self._fake_c_ops(False))
+        monkeypatch.setitem(sys.modules, "lmcache.lmcache_native", self._fake_native())
+        ops = _resolve_lmc_ops()
+        assert ops is not None
+        assert ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS == "F"
+        assert callable(ops.multi_layer_kv_transfer)
+
+    def test_enums_nowhere_returns_none(self, monkeypatch):
+        import sys
+
+        from maru_vllm.connector import _resolve_lmc_ops
+
+        monkeypatch.setitem(sys.modules, "lmcache.c_ops", self._fake_c_ops(False))
+        monkeypatch.setitem(sys.modules, "lmcache.lmcache_native", None)
+        assert _resolve_lmc_ops() is None
+
+    def test_kernels_missing_returns_none(self, monkeypatch):
+        import sys
+        import types as _types
+
+        from maru_vllm.connector import _resolve_lmc_ops
+
+        empty = _types.ModuleType("lmcache.c_ops")
+        monkeypatch.setitem(sys.modules, "lmcache.c_ops", empty)
+        monkeypatch.setitem(sys.modules, "lmcache.lmcache_native", self._fake_native())
+        assert _resolve_lmc_ops() is None
+
+
+class TestUseLmcacheKernelsFlag:
+    """maru_use_lmcache_kernels=false must force the per-layer paths without
+    ever attempting kernel resolution, regardless of what lmcache provides."""
+
+    def _make_worker(self, **extra):
+        from maru_vllm.connector import MaruWorkerConnector
+
+        return MaruWorkerConnector(block_size=4, kv_chunk_tokens=8, extra_config=extra)
+
+    def test_packed_kernel_ctx_skips_resolution_when_disabled(self):
+        worker = self._make_worker(maru_use_lmcache_kernels=False)
+        worker._kv_layout = SimpleNamespace(
+            format_name="NL_X_NB_TWO_BS_NH_HS",
+            block_size=4,
+            head_size=2,
+            page_buffer_size=64,
+        )
+        fake_layer = SimpleNamespace(
+            device=SimpleNamespace(type="cuda"), data_ptr=lambda: 0x1000
+        )
+        layers = [("model.layers.0.self_attn", fake_layer, 0)]
+
+        with patch("torch.cuda.is_available", return_value=True):
+            ctx = worker._packed_load_kernel_ctx(layers, MagicMock())
+
+        assert ctx is None
+        assert worker._lmc_ops is None  # resolution never attempted
+
+    def test_fused_load_disabled_when_kernels_off(self):
+        worker = self._make_worker(
+            maru_use_lmcache_kernels=False, maru_enable_fused_load=True
+        )
+        assert worker._ensure_fused_ops() is False
+        assert worker._fused_load is False
+        assert worker._lmc_ops is None
+
+    def test_default_keeps_kernels_enabled(self):
+        worker = self._make_worker()
+        assert worker._use_lmc_kernels is True
+
+
 class TestFusedLoad:
     CHUNK = 8
 

--- a/tests/unit/test_vllm_connector.py
+++ b/tests/unit/test_vllm_connector.py
@@ -2060,6 +2060,24 @@ class TestFusedLoad:
         assert ok is False
         assert ops.single_layer_kv_transfer.call_count == 0
 
+    def test_fused_survives_shim_ops_without_format_enum(self):
+        """LMCache 0.4.8rc5+ exposes c_ops through a device-ops shim that has
+        no EngineKVFormat attribute at all — the enum access itself raises
+        AttributeError. The lookup must absorb that and fall back instead of
+        letting the exception escape into the forward pass."""
+        worker = self._make_worker()
+        ops = self._fake_ops()
+        del ops.EngineKVFormat  # MagicMock: access now raises AttributeError
+        worker._lmc_ops = ops
+        worker._chunk_object_bytes = lambda: 128
+        kv_layer = torch.zeros(4, 2, 4, 1, 2)
+
+        ok = worker._fused_run_transfer(
+            kv_layer, memoryview(bytearray(256)), 1, torch.arange(self.CHUNK)
+        )
+        assert ok is False
+        assert ops.single_layer_kv_transfer.call_count == 0
+
     def test_fused_refuses_non_contiguous_cache(self):
         """A cache with HND strides whose layout resolved to an NHD format
         (the case _vllm_kv_cache_layout warns about: physical layout
@@ -2447,6 +2465,32 @@ class TestPackedStorage:
             kernel, metadata
         )
         assert worker._queued_store_batches == []
+
+    def test_packed_kernel_ctx_survives_shim_ops_without_format_enum(self):
+        """Same shim guard for the packed kernel resolution: a device-ops
+        shim lacking EngineKVFormat must resolve the ctx to None (per-layer
+        fallback) instead of raising out of save_kv_layer — the pre-guard
+        code killed the EngineCore here on the first request."""
+        worker, _ = self._make_worker()
+        ops = MagicMock()
+        del ops.EngineKVFormat  # access now raises AttributeError, like the shim
+        worker._lmc_ops = ops
+        worker._kv_layout = SimpleNamespace(
+            format_name="NL_X_NB_TWO_BS_NH_HS",
+            block_size=self.BLOCK,
+            head_size=2,
+            page_buffer_size=64,
+        )
+        fake_layer = SimpleNamespace(
+            device=SimpleNamespace(type="cuda"), data_ptr=lambda: 0x1000
+        )
+        layers = [("model.layers.0.self_attn", fake_layer, 0)]
+
+        with patch("torch.cuda.is_available", return_value=True):
+            ctx = worker._packed_load_kernel_ctx(layers, MagicMock())
+
+        assert ctx is None
+        assert ops.multi_layer_kv_transfer.call_count == 0
 
     def test_kernel_ctx_caching_contract(self):
         """_packed_store_kernel_ctx resolves once and caches the outcome:


### PR DESCRIPTION
## Symptom

With current upstream LMCache installed, the first inference request kills the vLLM EngineCore:

    File "maru_vllm/connector.py", line 2431, in _packed_load_kernel_ctx
        kv_format = getattr(ops.EngineKVFormat, layout.format_name, None)
    AttributeError: 'CudaDeviceOps' object has no attribute 'EngineKVFormat'

The exception escapes `save_kv_layer` inside the model forward, so the whole engine dies and every request through the frontend returns 500.

## Background: why the *direct* connector touches LMCache at all

`MaruKVConnector` is a direct vLLM↔maru integration — all cache decisions (chunk keys, placement, metadata, retrieval) are maru's, and no LMCache connector/engine/service ever runs. The only thing borrowed from the `lmcache` package is its **compiled CUDA kernels** (`multi_layer_kv_transfer` / `single_layer_kv_transfer`), used purely as a library to gather/scatter paged GPU KV blocks to/from contiguous CXL slabs in one kernel launch. This is optional by design: without the kernels the connector uses its per-layer fallback. (Unrelated to `maru_lmcache`, which is the opposite integration — running the real LMCache connector with maru as its storage backend.)

## Root cause

The kernel resolution handled two cases: lmcache not installed (`ImportError` guard → fallback) and installed-but-missing-a-format (`getattr(enum, name, None)` → fallback). Upstream LMCache created a third: the KV-type enums (`EngineKVFormat`, `TransferDirection`) were relocated out of `c_ops` into the `lmcache.lmcache_native` extension (LMCache/LMCache#4453), and the backward-compat forward was removed in #4473 (2026-08-12). `lmcache.c_ops` now resolves through a device-ops shim that carries the kernels but not the enums, so the *outer* attribute access raises before the guarded inner lookup runs.

## Fix

Two layers, one commit each:

1. **Guard the enum lookup itself** at both resolution sites (fused single-layer path and the packed load/store kernel ctx), so a c_ops handle without the enum takes the existing per-layer fallback instead of crashing.
2. **Resolve the enums from their new home.** A `_resolve_lmc_ops()` helper bundles whichever combination is present — kernels from `lmcache.c_ops`; enums from c_ops attributes (old builds, including the xcena fork) or from `lmcache.lmcache_native` (new upstream) — into one namespace with the legacy `ops.<name>` shape, so all call sites work unchanged against either LMCache generation and the fused path stays active on new upstream.

## New config: `maru_use_lmcache_kernels`

Added to `kv_connector_extra_config`. Type `bool`, default `true`.

| Value | Behavior |
| --- | --- |
| `true` (default) | Use LMCache's compiled transfer kernels for the packed GPU↔CXL copies when they can be resolved. If the kernels or enums are unavailable, the connector still degrades to the per-layer paths on its own. |
| `false` | Never touch lmcache — force the pure-torch per-layer paths even when lmcache is installed. |

Set `false` to benchmark the fallback paths or to isolate lmcache-related issues. Interaction: the experimental `maru_enable_fused_load=true` requires the kernels, so with this flag off it is disabled with a warning.

```json
"kv_connector_extra_config": { "maru_use_lmcache_kernels": false }
```

## Validation

- Unit: 9 new tests — shim-crash regressions (fail with the exact production `AttributeError` pre-fix), resolver across LMCache generations, toggle behavior. Full connector suite passes (172).
- E2E on real hardware (upstream LMCache post-#4473, Dynamo frontend + 2 `dynamo.vllm` workers, Qwen2.5-32B, CXL /dev/dax pool): previously crashed on the first request. With the fix, cross-instance KV reuse works and the fused kernels engage — the per-load fallback warning is absent, and against the guard-only fallback baseline the medians improved: cold (prefill+store) 1.374s → 1.062s, warm (CXL→GPU load) 0.135s → 0.124s. Fallback-path cross-instance speedup was 10.2× TTFT; the kernel path improves on it mainly on the store side at this KV size (1.1 GB/request).
- Correctness: `examples/vllm/p2p_sharing/p2p_example.sh` passes on the kernel path (`Cache Hit: Yes`).
