### PR TITLE
feat(maru_vllm): remove the LMCache dependency from the direct connector

### DIFF
--- a/docs/source/getting_started/examples/vllm/index.md
+++ b/docs/source/getting_started/examples/vllm/index.md
@@ -15,14 +15,15 @@ store and load paths before any cross-instance behavior is involved.
 ## Prerequisites
 
 - 1 GPU for the single-instance example, 2+ for P2P
-- Maru installed: `uv pip install -e /path/to/maru`
+- Maru installed with its KV placement kernels: `./install.sh` from the Maru
+  source tree, or `uv pip install -e /path/to/maru --no-build-isolation` in an
+  environment that already has PyTorch and the CUDA toolkit. The connector
+  carries its own CUDA kernels for the coalesced multi-layer transfers and
+  falls back to a transfer per layer without them, which is materially slower.
+  `python -c "import maru_kv_ops; print(maru_kv_ops.is_available())"` says
+  which path it will take.
 - vLLM v0.14+ installed
 - `maru-server` binary available
-
-LMCache is optional. When its Python package is present the direct connector
-reuses `lmcache.c_ops` for coalesced multi-layer CUDA transfers; it does not
-run the LMCache connector or service. Without `c_ops` the connector falls back
-to a per-layer transfer.
 
 ## Single-instance verification
 

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -76,7 +76,30 @@ To install **without the Resource Manager** (e.g., on nodes that only run LLM in
 
 <br/>
 
-### 1.3 Development Install
+### 1.3 KV Placement Kernels (vLLM connector)
+
+The vLLM connector moves a request's KV cache between a Maru CXL object and vLLM's paged cache with the CUDA kernels in `maru_kv_ops`. Those kernels are a build product of this package, and building them needs **PyTorch importable by the interpreter that will run the engine, plus the CUDA toolkit (`nvcc`)**. On a host without either, Maru installs anyway and the connector copies one layer at a time — correct, but materially slower, and the connector logs a warning naming this step.
+
+`install.sh` handles this: it looks for PyTorch in the target environment and, when it finds it, installs with `--no-build-isolation` so the build can see it, then reports whether the kernels are callable.
+
+Installing by hand needs that flag passed explicitly. An isolated build gets only the packages in `[build-system].requires`, so it never sees PyTorch and skips the kernels silently:
+
+```bash
+uv pip install setuptools wheel          # the build backend, in this environment
+uv pip install -e . --no-build-isolation
+```
+
+Check the result at any time:
+
+```bash
+python -c "import maru_kv_ops; print(maru_kv_ops.is_available(), maru_kv_ops.import_error())"
+```
+
+`True None` means the connector takes the kernel path. Anything else prints why it cannot, and `MARU_SKIP_KV_OPS=1` skips the build outright when that is what you want.
+
+<br/>
+
+### 1.4 Development Install
 
 To work on Maru itself, install the `dev` extra (pytest, mypy, ruff, pre-commit) instead of running `install.sh`:
 

--- a/examples/vllm/p2p_sharing/README.md
+++ b/examples/vllm/p2p_sharing/README.md
@@ -21,13 +21,15 @@ Instance 1 (GPU 0)                    Instance 2 (GPU 1)
 ## Prerequisites
 
 - 2+ NVIDIA GPUs
-- maru installed: `uv pip install -e /path/to/maru`
+- maru installed with its KV placement kernels: `./install.sh` from the maru
+  source tree, or `uv pip install -e /path/to/maru --no-build-isolation` in an
+  environment that already has PyTorch and the CUDA toolkit. The direct
+  connector carries its own CUDA kernels for the coalesced multi-layer
+  transfers and falls back to a transfer per layer without them, which is
+  materially slower. Check with
+  `python -c "import maru_kv_ops; print(maru_kv_ops.is_available())"`.
 - vLLM v0.14+ installed
 - maru-server binary available
-- LMCache is optional. When its Python package is installed, the direct
-  connector reuses `lmcache.c_ops` for coalesced multi-layer CUDA transfers;
-  it does not run the LMCache connector or service. Without `c_ops`, Maru uses
-  the compatible per-layer fallback.
 
 ## Quick Start (Automated)
 

--- a/examples/vllm/single/README.md
+++ b/examples/vllm/single/README.md
@@ -29,13 +29,15 @@ connector's store/load paths would never run.
 ## Prerequisites
 
 - 1+ NVIDIA GPU
-- maru installed: `uv pip install -e /path/to/maru`
+- maru installed with its KV placement kernels: `./install.sh` from the maru
+  source tree, or `uv pip install -e /path/to/maru --no-build-isolation` in an
+  environment that already has PyTorch and the CUDA toolkit. The direct
+  connector carries its own CUDA kernels for the coalesced multi-layer
+  transfers and falls back to a transfer per layer without them, which is
+  materially slower. Check with
+  `python -c "import maru_kv_ops; print(maru_kv_ops.is_available())"`.
 - vLLM v0.14+ installed
 - maru-server binary available
-- LMCache is optional. When its Python package is installed, the direct
-  connector reuses `lmcache.c_ops` for coalesced multi-layer CUDA transfers;
-  it does not run the LMCache connector or service. Without `c_ops`, Maru uses
-  the compatible per-layer fallback.
 
 ## Quick Start (Automated)
 

--- a/install.sh
+++ b/install.sh
@@ -79,10 +79,51 @@ else
     INSTALL_CMD=(pip install)
 fi
 
+# --- Decide whether the KV placement kernels can be built ------------------
+
+# setup.py describes the maru_kv_ops CUDA extension through
+# torch.utils.cpp_extension, so PyTorch has to be importable while the build
+# runs. A PEP 517 isolated build only gets the packages in
+# [build-system].requires, so it never sees the PyTorch installed in the target
+# environment and the extension is skipped without a word — the vLLM connector
+# then copies one layer at a time, which is materially slower. Turning
+# isolation off is what points the build at the interpreter the serving engine
+# uses, and it means the build backend has to be present there already.
+TARGET_PYTHON="${VIRTUAL_ENV:+${VIRTUAL_ENV}/bin/python}"
+TARGET_PYTHON="${TARGET_PYTHON:-$(command -v python3)}"
+
+BUILD_ARGS=()
+if "$TARGET_PYTHON" -c 'import torch' >/dev/null 2>&1; then
+    echo "PyTorch found; building Maru with the KV placement kernels ..."
+    "${INSTALL_CMD[@]}" "setuptools>=61.0" wheel
+    BUILD_ARGS=(--no-build-isolation)
+else
+    echo "Note: PyTorch is not installed in the target environment."
+    echo "      Maru installs without the KV placement kernels, and the vLLM"
+    echo "      connector falls back to a copy per layer. Install PyTorch and"
+    echo "      the CUDA toolkit, then rerun this script to build them."
+    echo ""
+fi
+
 # --- Install Python package ------------------------------------------------
 
 echo "Installing Maru Python package ..."
-"${INSTALL_CMD[@]}" -e "${SCRIPT_DIR}"
+"${INSTALL_CMD[@]}" ${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"} -e "${SCRIPT_DIR}"
+
+# --- Report whether the kernels are callable -------------------------------
+
+# An unbuilt extension raises nothing at runtime, so the install is where it
+# can still be reported against what was asked for.
+if [ ${#BUILD_ARGS[@]} -gt 0 ]; then
+    if "$TARGET_PYTHON" -c 'import maru_kv_ops, sys; sys.exit(0 if maru_kv_ops.is_available() else 1)' 2>/dev/null; then
+        echo "KV placement kernels: built."
+    else
+        echo ""
+        echo "Warning: the KV placement kernels did not build."
+        "$TARGET_PYTHON" -c 'import maru_kv_ops; print("         reason:", maru_kv_ops.import_error())' 2>/dev/null || true
+        echo "         The vLLM connector will use its slower per-layer copy path."
+    fi
+fi
 
 # --- Build and install resource manager ------------------------------------
 

--- a/maru_kv_ops/VENDOR.md
+++ b/maru_kv_ops/VENDOR.md
@@ -1,0 +1,61 @@
+# Vendored kernel sources
+
+`csrc/` holds paged-KV placement kernels copied from
+[LMCache](https://github.com/LMCache/LMCache). Both projects are Apache-2.0, and
+the SPDX headers on every copied file are retained.
+
+## Why these live here
+
+Maru's vLLM connector called `lmcache.c_ops` for its default KV copy path. That
+made LMCache a runtime requirement of a connector whose whole point is to reach
+Maru without LMCache, and the requirement was never declared: `pyproject.toml`
+listed only `pyzmq`, `msgpack` and `dacite`, and a missing LMCache degraded to a
+slower per-layer path behind one log line. Copying the kernels in removes the
+requirement and makes the copy path Maru's own to change.
+
+Design note and measured expectations:
+`_vault/_design/maru_vllm_direct/20260819_lmcache-kernel-dependency-removal.md`.
+
+## Source revision
+
+| | |
+|---|---|
+| Upstream | `github.com/LMCache/LMCache`, `csrc/` |
+| Revision | `43a3318e1c4ee471fd69316ba47a2aee3916c124` (2026-07-21) |
+| License | Apache-2.0 |
+| Modifications | None. Every file below is byte-identical to that revision. |
+
+The revision is **deliberately not upstream's latest.** It is the revision that
+the LMCache build Maru has been measured against was compiled from, so a
+vendored-vs-`lmcache.c_ops` comparison isolates the packaging change. Upstream
+has since moved these files on in four commits — `#4220` and `#4351` add engine
+KV formats, `#4200` optimises a retrieve path, and `#4431` refactors
+`EngineKVFormat` onto a `KVFormatSpec` and so changes the API surface. Picking
+those up is a separate step that needs its own on-device comparison.
+
+## Files
+
+| File | Role |
+|---|---|
+| `csrc/engine_kv_format.h` | Paged-cache axis orders the kernels index with |
+| `csrc/kv_transfer_types.h` | Transfer direction |
+| `csrc/mem_kernels.cuh` / `.cu` | Token-granular placement, all layers or one |
+| `csrc/mp_mem_kernels.cuh` / `.cu` | Block-granular placement |
+| `csrc/pybind.cpp` | **Maru's own.** Binds the three entry points Maru calls |
+
+`mem_kernels.cu` also defines four entry points Maru never calls (two SGLang
+variants and two the upstream header marks deprecated), and `mp_mem_kernels.cu`
+defines a transfer-plan executor Maru never calls. They are compiled and left
+unbound. Deleting them would shrink the build, but it would also mean the files
+are no longer byte-identical to a known upstream revision, which is what lets a
+refresh be a plain copy and a diff. The build cost is paid once per install.
+
+## Refreshing
+
+1. Copy the files listed above, minus `pybind.cpp`, from the target revision.
+2. Re-read `pybind.cpp` against the new headers: a signature or enum change
+   upstream shows up here as a compile error, which is the intent.
+3. Update the revision table above, including what moved and why.
+4. Re-run the connector unit tests, then compare against the previous revision
+   on device before adopting. A refresh changes kernel behaviour and cannot be
+   validated by unit tests alone.

--- a/maru_kv_ops/VENDOR.md
+++ b/maru_kv_ops/VENDOR.md
@@ -50,12 +50,37 @@ unbound. Deleting them would shrink the build, but it would also mean the files
 are no longer byte-identical to a known upstream revision, which is what lets a
 refresh be a plain copy and a diff. The build cost is paid once per install.
 
+### Copied contents
+
+SHA-256 of each file as copied from the revision above. `tests/unit/test_kv_ops.py`
+recomputes these, so a copy that lands without its revision being updated fails
+the suite instead of passing as the recorded revision.
+
+| File | SHA-256 |
+|---|---|
+| `csrc/engine_kv_format.h` | `cba3e779b1244ff32952afed2922e935bb582b8b493a62dfd5c6dde163de4d2f` |
+| `csrc/kv_transfer_types.h` | `80a56023fd6a2995467249016f05c4128acd2068edfba35df2e16230fb2dee9c` |
+| `csrc/mem_kernels.cu` | `c24fb1836d6fe8ad81cfabfae44551a3c958f1f58fa441ece8fbcf563e677741` |
+| `csrc/mem_kernels.cuh` | `829f00e9201b22e375969a0128139aa426f483e57553132aa27d9ddf70f378e2` |
+| `csrc/mp_mem_kernels.cu` | `ebfc61e4499382b63741f9323cadddca78f9dbee57d914dab0a20d7df32ad7b9` |
+| `csrc/mp_mem_kernels.cuh` | `aae0da1fd17773f6a4fe151e7bf20cc883ae7a45fa7327b1fa37cbe5adc7045e` |
+
+Regenerate with:
+
+```bash
+cd maru_kv_ops/csrc && sha256sum *.h *.cu *.cuh
+```
+
 ## Refreshing
 
 1. Copy the files listed above, minus `pybind.cpp`, from the target revision.
 2. Re-read `pybind.cpp` against the new headers: a signature or enum change
    upstream shows up here as a compile error, which is the intent.
-3. Update the revision table above, including what moved and why.
-4. Re-run the connector unit tests, then compare against the previous revision
+3. Update the revision table above, including what moved and why, and
+   regenerate the SHA-256 table with the command given there.
+4. Check that `single_layer_kv_transfer` still dispatches every format
+   `maru_vllm.kv_layout` emits — `tests/unit/test_kv_ops.py` reads the switch
+   in `mem_kernels.cu` and fails when one is dropped.
+5. Re-run the connector unit tests, then compare against the previous revision
    on device before adopting. A refresh changes kernel behaviour and cannot be
    validated by unit tests alone.

--- a/maru_kv_ops/__init__.py
+++ b/maru_kv_ops/__init__.py
@@ -19,6 +19,7 @@ Attributes:
 """
 
 # Standard
+import importlib as _importlib
 from typing import Any
 
 __all__ = [
@@ -42,8 +43,12 @@ try:
     # import fails with a missing-libc10 OSError even when it built fine.
     import torch  # noqa: F401
 
-    # Local
-    from maru_kv_ops import _C  # type: ignore[attr-defined]
+    # Imported by name rather than as ``from maru_kv_ops import _C``: this
+    # module is still executing, so a from-import of a submodule that was
+    # never built reports the partially initialised package and suggests a
+    # circular import. ``_IMPORT_ERROR`` is read out to operators verbatim, so
+    # it has to say the extension is missing.
+    _C = _importlib.import_module("maru_kv_ops._C")  # type: ignore[assignment]
 except Exception as exc:  # pragma: no cover - depends on build environment
     # Broad on purpose: a mismatched torch ABI raises neither ImportError nor
     # any other single type, and an unusable extension must degrade to the

--- a/maru_kv_ops/__init__.py
+++ b/maru_kv_ops/__init__.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Paged-KV placement kernels for the Maru serving-engine connectors.
+
+Moving a KV cache between a Maru CXL object and a serving engine's paged KV
+cache is not a copy: the engine scatters a request's tokens across fixed-size
+blocks, so every token's destination address has to be resolved from a mapping
+table. These kernels do that resolution on the device.
+
+The extension is built only where CUDA tooling is present, so importing this
+package always succeeds and ``is_available()`` reports whether the kernels can
+actually be called. Callers are expected to branch on it and keep whatever
+fallback they have — see ``MaruKVConnector._packed_load_kernel_ctx``.
+
+Attributes:
+    TransferDirection: H2D (object to paged cache) or D2H (paged cache to
+        object). Present only when the extension is available.
+    EngineKVFormat: Paged-cache axis order the kernels index with. Present only
+        when the extension is available.
+"""
+
+# Standard
+from typing import Any
+
+__all__ = [
+    "EngineKVFormat",
+    "PageBufferShapeDesc",
+    "TransferDirection",
+    "import_error",
+    "is_available",
+    "multi_layer_block_kv_transfer",
+    "multi_layer_kv_transfer",
+    "single_layer_kv_transfer",
+]
+
+_IMPORT_ERROR: Exception | None = None
+
+try:
+    # Third Party
+    # The extension links against libtorch, whose shared objects are found
+    # through the torch package's own loader. Importing it first is what puts
+    # libc10 and libtorch_cuda on the loader path; without this the extension
+    # import fails with a missing-libc10 OSError even when it built fine.
+    import torch  # noqa: F401
+
+    # Local
+    from maru_kv_ops import _C  # type: ignore[attr-defined]
+except Exception as exc:  # pragma: no cover - depends on build environment
+    # Broad on purpose: a mismatched torch ABI raises neither ImportError nor
+    # any other single type, and an unusable extension must degrade to the
+    # caller's fallback rather than break the import of maru_vllm.
+    _C = None  # type: ignore[assignment]
+    _IMPORT_ERROR = exc
+else:
+    EngineKVFormat = _C.EngineKVFormat
+    PageBufferShapeDesc = _C.PageBufferShapeDesc
+    TransferDirection = _C.TransferDirection
+    multi_layer_block_kv_transfer = _C.multi_layer_block_kv_transfer
+    multi_layer_kv_transfer = _C.multi_layer_kv_transfer
+    single_layer_kv_transfer = _C.single_layer_kv_transfer
+
+
+def is_available() -> bool:
+    """Report whether the compiled kernels can be called.
+
+    Returns:
+        True when the extension imported, so the module-level kernel and enum
+        attributes exist. False when it did not, in which case those attributes
+        are absent and ``import_error()`` explains why.
+    """
+    return _C is not None
+
+
+def import_error() -> Exception | None:
+    """Return why the extension is unavailable.
+
+    Returns:
+        The exception raised while importing the extension, or None when the
+        extension imported successfully.
+    """
+    return _IMPORT_ERROR
+
+
+def __getattr__(name: str) -> Any:
+    """Explain an unavailable extension instead of raising a bare NameError.
+
+    Only reached for the kernel and enum names, which are bound at import time
+    when the extension is available.
+
+    Args:
+        name: Attribute being looked up.
+
+    Returns:
+        Never returns; always raises.
+
+    Raises:
+        AttributeError: Always, naming the build requirement for kernel and
+            enum attributes and the module for anything else.
+    """
+    if name in __all__:
+        raise AttributeError(
+            f"maru_kv_ops.{name} is unavailable: the CUDA extension was not "
+            f"built or failed to import ({_IMPORT_ERROR}). Reinstall maru on a "
+            "host with the CUDA toolkit (nvcc) and PyTorch to build it."
+        )
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/maru_kv_ops/csrc/engine_kv_format.h
+++ b/maru_kv_ops/csrc/engine_kv_format.h
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Physical KV-cache memory layout an engine hands to LMCache, plus the
+// classification predicates over it. Vendor-header-free, so every backend and
+// the Python facade (lmc_ops) share one definition. Detection (raw layout ->
+// format) lives in lmcache/v1/gpu_connector/kv_format.
+
+/*
+Symbol Reference:
+NL: number of layers
+NB: number of blocks/pages
+BS: block/page size
+NBBS: block/page buffer size = NB * BS
+NH: number of heads
+HS: head size
+TWO: 2
+ONE: 1
+
+_ means a dimension within the same tensor
+_X_ means a dimension across a list
+
+A_X_B_X_C_D_E means:
+kv_cache: List[List[torch.Tensor]]
+len(kv_cache) = A
+len(kv_cache[0]) = B
+kv_cache[0][0].shape = (C, D, E)
+*/
+enum class EngineKVFormat : int {
+  NB_NL_TWO_BS_NH_HS = 0,
+  /*
+  used by:
+  - vLLM CROSS_LAYER mode
+  */
+
+  NL_X_TWO_NB_BS_NH_HS = 1,
+  /*
+  used by:
+  - vLLM non-MLA flash attention
+  */
+
+  NL_X_NB_TWO_BS_NH_HS = 2,
+  /*
+  used by:
+  - vLLM non-MLA flash infer
+  */
+
+  NL_X_NB_BS_HS = 3,
+  /*
+  used by:
+  - vLLM MLA
+  */
+
+  TWO_X_NL_X_NBBS_NH_HS = 4,
+  /*
+  used by:
+  - SGLang MHA (flash attention and flash infer)
+  */
+
+  NL_X_NBBS_ONE_HS = 5,
+  /*
+  used by:
+  - SGLang MLA
+  */
+
+  NL_X_TWO_NB_NH_BS_HS = 6,
+  /*
+  used by:
+  - vLLM non-MLA flash attention (HND layout)
+  physical shape per layer: [2, num_blocks, num_heads, block_size, head_size]
+  */
+
+  NL_X_NB_TWO_NH_BS_HS = 7,
+  /*
+  used by:
+  - vLLM non-MLA flash infer (HND layout)
+  physical shape per layer: [num_blocks, 2, num_heads, block_size, head_size]
+  */
+
+  NB_NL_TWO_NH_BS_HS = 8,
+  /*
+  used by:
+  - TRT-LLM cross-layer (HND layout)
+  physical shape: [num_blocks, num_layers, 2, num_heads, block_size, head_size]
+  */
+
+  TWO_X_NL_X_NB_BS_NH_HS = 9,
+  /*
+  used by:
+  - SGLang MHA via the MP daemon path
+  physical shape per layer: [num_blocks, block_size, num_heads, head_size]
+  */
+
+  NL_X_NB_NH_BS_TWO_HS = 10,
+  /*
+  used by:
+  - vLLM non-MLA blocks-first attention with K/V fused into the trailing dim
+  physical shape per layer: [num_blocks, num_heads, block_size, 2, head_size]
+  (recovered by splitting the fused trailing [block_size, 2 * head_size]).
+  The device transfer kernels treat it as HND with kv_size == 1 and
+  hs == 2 * head_size (the K/V axis stays packed inside each head copy).
+  */
+
+  NL_X_NB_BS_NH_TWO_HS = 11,
+  /*
+  used by:
+  - vLLM non-MLA blocks-first attention (NHD layout) with K/V fused into the
+    trailing dim
+  physical shape per layer: [num_blocks, block_size, num_heads, 2, head_size]
+  (recovered by splitting the fused trailing [num_heads, 2 * head_size]).
+  Like NL_X_NB_NH_BS_TWO_HS but tokens before heads; the device transfer
+  kernels treat it as NHD with kv_size == 1 and hs == 2 * head_size.
+  */
+};
+
+// __host__ __device__ under CUDA/HIP so the kernels can call these; the guard
+// keeps the header vendor-runtime-free.
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  #define LMC_KV_FORMAT_HD __host__ __device__
+#else
+  #define LMC_KV_FORMAT_HD
+#endif
+
+// Structural shape of the normalized kv_caches: exactly one is true per format.
+
+// All layers in one fused tensor.
+LMC_KV_FORMAT_HD constexpr bool is_cross_layer(EngineKVFormat f) {
+  return f == EngineKVFormat::NB_NL_TWO_BS_NH_HS ||
+         f == EngineKVFormat::NB_NL_TWO_NH_BS_HS;
+}
+
+// Keys and values in two separate top-level lists: [key_layers, value_layers].
+LMC_KV_FORMAT_HD constexpr bool is_kv_list(EngineKVFormat f) {
+  return f == EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS ||
+         f == EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS;
+}
+
+// One list entry per layer: kv_caches[layer_idx] is that layer's tensor.
+LMC_KV_FORMAT_HD constexpr bool is_layer_list(EngineKVFormat f) {
+  return f == EngineKVFormat::NL_X_TWO_NB_BS_NH_HS ||
+         f == EngineKVFormat::NL_X_NB_TWO_BS_NH_HS ||
+         f == EngineKVFormat::NL_X_NB_BS_HS ||
+         f == EngineKVFormat::NL_X_NBBS_ONE_HS ||
+         f == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS ||
+         f == EngineKVFormat::NL_X_NB_TWO_NH_BS_HS ||
+         f == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS ||
+         f == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS;
+}
+
+// Multi-head Latent Attention: a single latent KV head (no separate K/V split).
+LMC_KV_FORMAT_HD constexpr bool is_mla(EngineKVFormat f) {
+  return f == EngineKVFormat::NL_X_NB_BS_HS ||   // vLLM MLA
+         f == EngineKVFormat::NL_X_NBBS_ONE_HS;  // SGLang MLA
+}
+
+// vLLM fused K/V: K and V packed in the trailing dim (2 * head_size), no
+// separate K/V axis — transferred as one k_or_v == 0 pass (like MLA).
+LMC_KV_FORMAT_HD constexpr bool is_fused_packed(EngineKVFormat f) {
+  return f == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS ||  // fused HND
+         f == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS;    // fused NHD
+}

--- a/maru_kv_ops/csrc/kv_transfer_types.h
+++ b/maru_kv_ops/csrc/kv_transfer_types.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Backend-agnostic transfer descriptors, free of any vendor runtime headers so
+// every backend (CUDA, ROCm, MUSA, SYCL/XPU, ...) shares one definition.
+
+#include "engine_kv_format.h"  // EngineKVFormat + its classification predicates
+
+enum class TransferDirection : int {
+  H2D = 0,
+  D2H = 1,
+};

--- a/maru_kv_ops/csrc/mem_kernels.cu
+++ b/maru_kv_ops/csrc/mem_kernels.cu
@@ -1,0 +1,1127 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <torch/all.h>
+#include <c10/cuda/CUDAGuard.h>
+#include "mem_kernels.cuh"
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <algorithm>
+#ifdef USE_ROCM
+  #include <hip/hip_fp8.h>
+#else
+  #include <cuda_fp8.h>
+#endif
+
+#ifndef CHECK_CUDA_CALL
+  #define CHECK_CUDA_CALL(call)                                             \
+    do {                                                                    \
+      cudaError_t err = call;                                               \
+      if (err != cudaSuccess) {                                             \
+        fprintf(stderr, "CUDA error in file '%s' in line %i : %s.\n",       \
+                __FILE__, __LINE__, cudaGetErrorString(err));               \
+        throw std::runtime_error(                                           \
+            std::string("CUDA error in file '") + __FILE__ + "' in line " + \
+            std::to_string(__LINE__) + " : " + cudaGetErrorString(err));    \
+      }                                                                     \
+    } while (0)
+#endif
+
+namespace lmc {
+
+// inline helper to check HND layout (callable from device and host)
+__host__ __device__ __forceinline__ bool is_hnd(
+    const EngineKVFormat engine_kv_format) {
+  return engine_kv_format ==
+             EngineKVFormat::NL_X_TWO_NB_NH_BS_HS ||  // flash attn HND
+         engine_kv_format ==
+             EngineKVFormat::NL_X_NB_TWO_NH_BS_HS;  // flash infer HND
+}
+
+// All paged (non-MLA) formats rely on block_size for offset computation.
+inline void check_block_size(const EngineKVFormat engine_kv_format,
+                             const int block_size) {
+  TORCH_CHECK(is_mla(engine_kv_format) || block_size > 0,
+              "block_size is required (must be > 0) for EngineKVFormat ",
+              static_cast<int>(engine_kv_format));
+}
+
+// HND formats additionally need head_size to decompose scalar offsets.
+inline void check_head_size(const EngineKVFormat engine_kv_format,
+                            const int head_size) {
+  TORCH_CHECK(!is_hnd(engine_kv_format) || head_size > 0,
+              "head_size is required (must be > 0) for EngineKVFormat ",
+              static_cast<int>(engine_kv_format));
+}
+
+template <typename scalar_t>
+__global__ void load_and_reshape_flash_kernel(
+    scalar_t* __restrict__ key_value,  // [num_tokens, num_heads, head_size]
+    const scalar_t* __restrict__ key_cache,    // [num_blocks, block_size,
+                                               // num_heads, head_size]
+    const scalar_t* __restrict__ value_cache,  // [num_blocks, block_size,
+                                               // num_heads, head_size]
+    const int64_t* __restrict__ slot_mapping,  // [num_tokens]
+    const int block_stride_in_64bit, const int key_value_stride,
+    const int num_heads, const int head_size_in_64bit, const int block_size,
+    const int key_layer_offset, const int value_layer_offset) {
+  const int64_t token_idx = blockIdx.x;
+  const int64_t slot_idx = slot_mapping[token_idx];
+
+  if (slot_idx < 0) {
+    return;
+  }
+
+  const int64_t block_idx = slot_idx / block_size;
+  const int64_t block_offset = slot_idx % block_size;
+  const int n = num_heads * head_size_in_64bit;
+
+  for (int i = threadIdx.x; i < n; i += blockDim.x) {
+    const int64_t tgt_key_idx =
+        key_layer_offset + token_idx * key_value_stride + i;
+    const int64_t tgt_value_idx =
+        value_layer_offset + token_idx * key_value_stride + i;
+
+    const int head_idx = i / head_size_in_64bit;
+    const int head_offset = i % head_size_in_64bit;
+    const int64_t src_key_value_idx =
+        block_idx * block_stride_in_64bit +
+        block_offset * num_heads * head_size_in_64bit +
+        head_idx * head_size_in_64bit + head_offset;
+
+    scalar_t tgt_key = key_cache[src_key_value_idx];
+    scalar_t tgt_value = value_cache[src_key_value_idx];
+
+    key_value[tgt_key_idx] = tgt_key;
+    key_value[tgt_value_idx] = tgt_value;
+  }
+}
+
+template <typename scalar_t>
+__global__ void reshape_and_cache_back_flash_kernel(
+    const scalar_t* __restrict__ key_value,  // [num_tokens, num_heads,
+                                             // head_size]
+    scalar_t* __restrict__ key_cache,    // [num_blocks, block_size, num_heads,
+                                         // head_size]
+    scalar_t* __restrict__ value_cache,  // [num_blocks, block_size, num_heads,
+                                         // head_size]
+    const int64_t* __restrict__ slot_mapping,  // [num_tokens]
+    const int block_stride_in_64bit, const int key_value_stride,
+    const int num_heads, const int head_size_in_64bit, const int block_size,
+    const int key_layer_offset, const int value_layer_offset) {
+  const int64_t token_idx = blockIdx.x;
+  const int64_t slot_idx = slot_mapping[token_idx];
+
+  if (slot_idx < 0) {
+    return;
+  }
+
+  const int64_t block_idx = slot_idx / block_size;
+  const int64_t block_offset = slot_idx % block_size;
+  const int n = num_heads * head_size_in_64bit;
+
+  for (int i = threadIdx.x; i < n; i += blockDim.x) {
+    const int64_t tgt_key_idx =
+        key_layer_offset + token_idx * key_value_stride + i;
+    const int64_t tgt_value_idx =
+        value_layer_offset + token_idx * key_value_stride + i;
+
+    const int head_idx = i / head_size_in_64bit;
+    const int head_offset = i % head_size_in_64bit;
+    const int64_t src_key_value_idx =
+        block_idx * block_stride_in_64bit +
+        block_offset * num_heads * head_size_in_64bit +
+        head_idx * head_size_in_64bit + head_offset;
+
+    scalar_t tgt_key = key_value[tgt_key_idx];
+    scalar_t tgt_value = key_value[tgt_value_idx];
+
+    key_cache[src_key_value_idx] = tgt_key;
+    value_cache[src_key_value_idx] = tgt_value;
+  }
+}
+
+template <typename scalar_t, EngineKVFormat format>
+__global__ void single_layer_kv_transfer_kernel(
+    scalar_t* __restrict__ lmc_key_value_cache,
+    scalar_t* __restrict__ vllm_key_value_cache,
+    const int64_t* __restrict__ slot_mapping,  // [num_tokens]
+    const int vllm_block_key_stride_in_64bit, const int vllm_value_offset,
+    const int lmc_stride, const int lmc_value_offset, const int num_heads,
+    const int head_size_in_64bit, const int block_size,
+    const TransferDirection direction) {
+  constexpr bool USE_MLA = (format == EngineKVFormat::NL_X_NB_BS_HS);
+  constexpr bool HND_LAYOUT = (format == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS ||
+                               format == EngineKVFormat::NL_X_NB_TWO_NH_BS_HS);
+
+  const int64_t token_idx = blockIdx.x;
+  const int64_t slot_idx = slot_mapping[token_idx];
+
+  if (slot_idx < 0) {
+    return;
+  }
+
+  const int64_t block_idx = slot_idx / block_size;
+  const int64_t block_offset = slot_idx % block_size;
+  const int n = num_heads * head_size_in_64bit;
+
+  for (int i = threadIdx.x; i < n; i += blockDim.x) {
+    const int64_t lmc_key_idx = token_idx * lmc_stride + i;
+
+    const int head_idx = i / head_size_in_64bit;
+    const int head_offset = i % head_size_in_64bit;
+
+    int64_t vllm_key_idx;
+    if constexpr (HND_LAYOUT) {
+      // HND layout: [..., num_heads, block_size, head_size]
+      vllm_key_idx = block_idx * vllm_block_key_stride_in_64bit +
+                     head_idx * block_size * head_size_in_64bit +
+                     block_offset * head_size_in_64bit + head_offset;
+    } else {
+      // NHD layout: [..., block_size, num_heads, head_size]
+      // (also correct for MLA where num_heads==1)
+      vllm_key_idx = block_idx * vllm_block_key_stride_in_64bit +
+                     block_offset * num_heads * head_size_in_64bit +
+                     head_idx * head_size_in_64bit + head_offset;
+    }
+
+    if (direction == TransferDirection::D2H) {
+      // GPU to LMCache
+      lmc_key_value_cache[lmc_key_idx] = vllm_key_value_cache[vllm_key_idx];
+      if constexpr (!USE_MLA) {
+        const int64_t lmc_value_idx = lmc_key_idx + lmc_value_offset;
+        const int64_t vllm_value_idx = vllm_key_idx + vllm_value_offset;
+        lmc_key_value_cache[lmc_value_idx] =
+            vllm_key_value_cache[vllm_value_idx];
+      }
+    } else {
+      // LMCache to GPU
+      vllm_key_value_cache[vllm_key_idx] = lmc_key_value_cache[lmc_key_idx];
+      if constexpr (!USE_MLA) {
+        const int64_t lmc_value_idx = lmc_key_idx + lmc_value_offset;
+        const int64_t vllm_value_idx = vllm_key_idx + vllm_value_offset;
+        vllm_key_value_cache[vllm_value_idx] =
+            lmc_key_value_cache[lmc_value_idx];
+      }
+    }
+  }
+}
+
+template <EngineKVFormat format>
+__device__ __forceinline__ int64_t page_buffer_offset(
+    const int k_or_v, const int token_idx, const int scalar_offset,
+    const int scalars_per_token, const int page_buffer_size,
+    const int block_size, const int head_size) {
+  /*
+  logical semantics of arguments (agnostic to physical format):
+  k_or_v:            0 for key, 1 for value
+  token_idx:         flat slot index from slot_mapping[] = block_id * block_size
+  + offset_in_block scalar_offset:     thread-loop index in [0,
+  scalars_per_token), flat offset within one token's data (NH*HS in xword units)
+  scalars_per_token: NH * HS in xword units — total data elements per token slot
+  page_buffer_size:  NB * BS — total token slots in the paged buffer
+  block_size:        BS — number of token slots per block
+  head_size:         HS in xword units — only used by HND formats to decompose
+  scalar_offset into (head_idx, head_offset)
+
+  The job of page_buffer_offset is to translate these logical arguments into a
+  physical address based on the EngineKVFormat.
+
+  NOTE(perf): For HND formats, threads within a warp access non-contiguous
+  addresses when crossing head boundaries (stride BS*HS between heads),
+  harming memory coalescing
+  TODO: A dedicated HND kernel could launch with
+  grid=(2, L, T*NH) thread=(HS,,) to keep warps within one head's contiguous
+  HS run
+  However, most models have head_size = 128 using bf16 or fp16 which is 256
+  bytes when divided by xwords (8 bytes) is exactly 32 xwords which fits one
+  warp Worst case if HS is smaller or quantization is smaller, we will have to
+  make two vectorized loads per warp that are BS * HS (the head stride) apart
+  */
+
+  // vllm cross layer
+  if constexpr (format == EngineKVFormat::NB_NL_TWO_BS_NH_HS) {
+    return k_or_v * page_buffer_size * scalars_per_token +
+           token_idx * scalars_per_token + scalar_offset;
+  }
+  // vllm flash attention (NHD)
+  else if constexpr (format == EngineKVFormat::NL_X_TWO_NB_BS_NH_HS) {
+    return k_or_v * page_buffer_size * scalars_per_token +
+           token_idx * scalars_per_token + scalar_offset;
+  }
+  // vllm flash infer (NHD)
+  else if constexpr (format == EngineKVFormat::NL_X_NB_TWO_BS_NH_HS) {
+    const int block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    return block_idx * 2 * block_size * scalars_per_token +
+           k_or_v * block_size * scalars_per_token +
+           block_offset * scalars_per_token + scalar_offset;
+  }
+  // MLA formats: vLLM (NL_X_NB_BS_HS) and SGLang (NL_X_NBBS_ONE_HS)
+  else if constexpr (format == EngineKVFormat::NL_X_NB_BS_HS ||
+                     format == EngineKVFormat::NL_X_NBBS_ONE_HS) {
+    return token_idx * scalars_per_token + scalar_offset;
+  }
+  // vllm flash attention (HND) — physical: [2, NB, NH, BS, HS]
+  else if constexpr (format == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS) {
+    const int block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int head_idx = scalar_offset / head_size;
+    const int head_offset = scalar_offset % head_size;
+    const int num_heads = scalars_per_token / head_size;
+    return k_or_v * page_buffer_size * scalars_per_token +
+           block_idx * num_heads * block_size * head_size +
+           head_idx * block_size * head_size + block_offset * head_size +
+           head_offset;
+  }
+  // vllm flash infer (HND) — physical: [NB, 2, NH, BS, HS]
+  else if constexpr (format == EngineKVFormat::NL_X_NB_TWO_NH_BS_HS) {
+    const int block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int head_idx = scalar_offset / head_size;
+    const int head_offset = scalar_offset % head_size;
+    const int num_heads = scalars_per_token / head_size;
+    return block_idx * 2 * num_heads * block_size * head_size +
+           k_or_v * num_heads * block_size * head_size +
+           head_idx * block_size * head_size + block_offset * head_size +
+           head_offset;
+  }
+  // Fused-K/V HND: [NB, NH, BS, 2*HS]. HND addressing like NL_X_TWO_NB_NH_BS_HS
+  // but no K/V plane (k_or_v == 0) and per-head width 2*head_size (K+V packed).
+  else if constexpr (format == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS) {
+    const int hs2 = 2 * head_size;  // packed K+V width per head (xword units)
+    const int block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int head_idx = scalar_offset / hs2;
+    const int head_offset = scalar_offset % hs2;
+    const int num_heads = scalars_per_token / hs2;
+    return block_idx * num_heads * block_size * hs2 +
+           head_idx * block_size * hs2 + block_offset * hs2 + head_offset;
+  }
+  // Fused-K/V NHD: [NB, BS, NH, 2*HS]. token_idx already encodes the slot, so
+  // the packed per-token stride lands directly on it (k_or_v == 0).
+  else if constexpr (format == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS) {
+    return token_idx * scalars_per_token + scalar_offset;
+  }
+}
+
+__device__ __forceinline__ int64_t page_buffer_offset_unilateral(
+    const int token_idx, const int scalar_offset, const int scalars_per_token) {
+  return token_idx * scalars_per_token + scalar_offset;
+}
+
+__device__ __forceinline__ int64_t
+key_value_offset(const int k_or_v, const int layer_idx, const int token_idx,
+                 const int scalar_offset, const int scalars_per_token,
+                 const int num_tokens, const int num_layers) {
+  return k_or_v * num_layers * num_tokens * scalars_per_token +
+         layer_idx * num_tokens * scalars_per_token +
+         token_idx * scalars_per_token + scalar_offset;
+}
+
+template <typename scalar_t>
+__global__ void single_layer_kv_transfer_sgl_kernel(
+    // scalar_t* __restrict__ lmc_key_cache,    // [num_tokens,
+    // num_heads*head_size] scalar_t* __restrict__ lmc_value_cache,  //
+    // [num_tokens, num_heads*head_size]
+    scalar_t* __restrict__ lmc_key_value_cache,  // [num_tokens, 2,
+                                                 // num_heads*head_size]
+                                                 // or
+                                                 // [2, num_tokens,
+                                                 // num_heads*head_size]
+    scalar_t* __restrict__ sgl_key_cache,        // [num_blocks, block_size,
+                                                 // num_heads, head_size]
+    scalar_t* __restrict__ sgl_value_cache,      // [num_blocks, block_size,
+                                                 // num_heads, head_size]
+    const int64_t* __restrict__ slot_mapping,    // [num_tokens]
+    const int block_stride_in_64bit, const int lmc_stride,
+    const int lmc_value_offset, const int num_heads,
+    const int head_size_in_64bit, const int block_size,
+    const TransferDirection direction) {
+  const int64_t token_idx = blockIdx.x;
+  const int64_t slot_idx = slot_mapping[token_idx];
+
+  if (slot_idx < 0) {
+    return;
+  }
+
+  const int64_t block_idx = slot_idx / block_size;
+  const int64_t block_offset = slot_idx % block_size;
+  const int n = num_heads * head_size_in_64bit;
+
+  for (int i = threadIdx.x; i < n; i += blockDim.x) {
+    const int64_t lmc_key_idx = token_idx * lmc_stride + i;
+    const int64_t lmc_value_idx = lmc_key_idx + lmc_value_offset;
+
+    const int head_idx = i / head_size_in_64bit;
+    const int head_offset = i % head_size_in_64bit;
+    const int64_t sgl_key_value_idx =
+        block_idx * block_stride_in_64bit +
+        block_offset * num_heads * head_size_in_64bit +
+        head_idx * head_size_in_64bit + head_offset;
+
+    if (direction == TransferDirection::D2H) {
+      lmc_key_value_cache[lmc_key_idx] = sgl_key_cache[sgl_key_value_idx];
+      lmc_key_value_cache[lmc_value_idx] = sgl_value_cache[sgl_key_value_idx];
+    } else {  // direction == TransferDirection::H2D
+      sgl_key_cache[sgl_key_value_idx] = lmc_key_value_cache[lmc_key_idx];
+      sgl_value_cache[sgl_key_value_idx] = lmc_key_value_cache[lmc_value_idx];
+    }
+  }
+}
+
+/**
+ * Quickly load KV cache between vLLM paged memory and offloading buffer
+ * slot_id = slot_mapping[block.x]
+ * key_value[block.z, block.y, block.x, thread.x] <=> ptrs[block.y][block.z,
+ * slot_id, thread.x]
+ */
+template <typename scalar_t, bool DIRECTION, EngineKVFormat format>
+__global__ void load_and_reshape_multi_layer_kernel(
+    scalar_t* __restrict__ key_value,           // [2, num_layer, num_tokens,
+                                                // scalars_per_token]
+    scalar_t** __restrict__ paged_buffer_ptrs,  // [num_layers] * [2,
+                                                // PAGE_BUFFER_SIZE,
+                                                // scalars_per_token]
+                                                // or
+                                                // [num_layers] * [num_blocks,
+                                                // 2, block_size,
+                                                // scalars_per_token]
+    const int64_t* __restrict__ slot_mapping,   // [num_tokens]
+    const int scalars_per_token, const int num_tokens, const int num_layers,
+    const int page_buffer_size, const int block_size, const int head_size,
+    const int skip_prefix_n_tokens) {
+  const int token_id = blockIdx.x;
+  const int layer_id = blockIdx.y;
+  const int k_or_v = blockIdx.z;
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+
+  const int kv_token_id = token_id + skip_prefix_n_tokens;
+  const int64_t slot_idx = slot_mapping[kv_token_id];
+  scalar_t* paged_buffer_ptr = paged_buffer_ptrs[layer_id];
+
+  if (slot_idx < 0) {
+    return;
+  }
+
+  /** Copy the data from page buffer to key_value **/
+  for (int i = tid; i < scalars_per_token; i += num_threads) {
+    const int64_t lmcache_offset =
+        key_value_offset(k_or_v, layer_id, kv_token_id, i, scalars_per_token,
+                         num_tokens, num_layers);
+
+    const int64_t vllm_offset =
+        page_buffer_offset<format>(k_or_v, slot_idx, i, scalars_per_token,
+                                   page_buffer_size, block_size, head_size);
+
+    if (DIRECTION)  // 1 is paged buffer to LMCache
+      key_value[lmcache_offset] = paged_buffer_ptr[vllm_offset];
+    else  // 0 is LMCache to paged buffer
+      paged_buffer_ptr[vllm_offset] = key_value[lmcache_offset];
+  }
+}
+
+/*
+ * handle sglang MHA offload between CPU and GPU
+ * DIRECTION = 1 (true) means paged buffer to LMCache (D2H)
+ * DIRECTION = 0 (false) means LMCache to paged buffer (H2D)
+ */
+template <typename scalar_t, bool DIRECTION>
+__global__ void load_and_reshape_multi_layer_kernel_unilateral(
+    scalar_t* __restrict__ key_value,           // [2, num_layer, num_tokens,
+                                                // scalars_per_token]
+    scalar_t** __restrict__ paged_buffer_ptrs,  // [num_layers *2] *
+                                                // [PAGE_BUFFER_SIZE,
+                                                // scalars_per_token]
+    const int64_t* __restrict__ slot_mapping,   // [num_tokens]
+    const int scalars_per_token, const int num_tokens, const int num_layers,
+    const int page_buffer_size) {
+  const int token_id = blockIdx.x;
+  const int layer_id = blockIdx.y;
+  const int k_or_v = blockIdx.z;
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+
+  const int64_t slot_idx = slot_mapping[token_id];
+  scalar_t* key_ptr = paged_buffer_ptrs[layer_id];
+  scalar_t* value_ptr = paged_buffer_ptrs[layer_id + num_layers];
+
+  if (slot_idx < 0) {
+    return;
+  }
+
+  /** Copy the data from page buffer to key_value **/
+  for (int i = tid; i < scalars_per_token; i += num_threads) {
+    const int64_t lmcache_offset =
+        key_value_offset(k_or_v, layer_id, token_id, i, scalars_per_token,
+                         num_tokens, num_layers);
+
+    const int64_t sgl_offset =
+        page_buffer_offset_unilateral(slot_idx, i, scalars_per_token);
+
+    if (k_or_v == 0) {
+      if (DIRECTION)  // 1 is paged buffer to LMCache
+        key_value[lmcache_offset] = key_ptr[sgl_offset];
+      else  // 0 is LMCache to paged buffer
+        key_ptr[sgl_offset] = key_value[lmcache_offset];
+    } else {
+      if (DIRECTION)  // 1 is paged buffer to LMCache
+        key_value[lmcache_offset] = value_ptr[sgl_offset];
+      else  // 0 is LMCache to paged buffer
+        value_ptr[sgl_offset] = key_value[lmcache_offset];
+    }
+  }
+}
+
+}  // namespace lmc
+
+template <typename T, typename TENSOR_TYPE>
+T* get_kernel_ptr(TENSOR_TYPE& tensor) {
+  // Get the kernel-accessible pointer of the given type T
+  // Returns NULL if the tensor is on CPU and non-pinned
+  torch::Device device = tensor.device();
+  if (device.is_cuda()) {
+    return static_cast<T*>(tensor.data_ptr());
+  } else if (device.is_cpu()) {
+    T* ptr;
+    auto st = cudaHostGetDevicePointer(
+        (void**)&ptr, static_cast<void*>(tensor.data_ptr()), 0);
+    TORCH_CHECK(st == cudaSuccess,
+                "Host tensor not registered/pinned (or bad ptr)");
+    return ptr;
+  } else {
+    TORCH_CHECK(false, "Invalid device. Device must be cuda or pinned cpu.");
+  }
+}
+
+/**
+ * Quickly offload KV cache from vLLM paged memory to the offloading buffer
+ * Processes all the layers at the same time
+ *
+ * Each layer in vLLM's KV buffer has a shape of
+ * [2, PAGE_BUFFER_SIZE, num_heads*head_size]
+ *
+ * Each thread block processes the copy for a token
+ * The grid size should be (num_tokens, num_layers, 2)
+ *
+ * Therefore:
+ *  - k/v -- block.z
+ *  - layer id -- block.y
+ *  - token id -- block.x
+ *  - offset within a token -- thread.x
+ *
+ * The function does:
+ * slot_id = slot_mapping[block.x]
+ * key_value[block.z, block.y, block.x, thread.x] = ptrs[block.y][block.z,
+ * slot_id, thread.x]
+ *
+ * Param:
+ *  - direction: H2D  means LMCache to PagedBuffer, D2H  means PagedBuffer to
+ * LMCache
+ */
+#define LAUNCH_KERNEL_WITH_FORMAT(T, DIRECTION, FORMAT)                      \
+  lmc::load_and_reshape_multi_layer_kernel<T, DIRECTION, FORMAT>             \
+      <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,          \
+                                   slot_mapping_ptr, num_xwords, num_tokens, \
+                                   num_layers, page_buffer_size, block_size, \
+                                   head_size_xword, skip_prefix_n_tokens);   \
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+template <typename T>
+void multi_layer_kv_transfer_templated(
+    torch::Tensor&
+        key_value,  // key/value must be on gpu/pinned cpu.
+                    // [2, num_layer, num_tokens, num_heads*head_size] for
+                    // flash_attn.
+                    // [1, num_layer, num_tokens, aligned_head_size]
+                    // for MLA.
+    const torch::Tensor& key_value_ptrs,  // [num_layers]
+    const torch::Tensor& slot_mapping,    // [num_tokens],
+    const torch::Device& paged_memory_device, const int page_buffer_size,
+    const TransferDirection direction, const EngineKVFormat engine_kv_format,
+    const int block_size, const int head_size, const int skip_prefix_n_tokens) {
+  T* key_value_ptr = get_kernel_ptr<T, torch::Tensor>(key_value);
+  T** page_buffer_ptrs =
+      get_kernel_ptr<T*, const torch::Tensor>(key_value_ptrs);
+  const int64_t* slot_mapping_ptr =
+      get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
+
+  int num_layers = key_value.size(1);
+  int num_tokens = key_value.size(2);
+  int num_transfer_tokens = num_tokens - skip_prefix_n_tokens;
+  int num_origin_elements = key_value.size(3);
+  int elements_per_xword = sizeof(T) / key_value.element_size();
+  int num_xwords = num_origin_elements / elements_per_xword;
+  // head_size is in element units
+  // convert to xword units
+  // to match scalars_per_token (num_xwords) which is also in xword units.
+  int head_size_xword = head_size > 0 ? head_size / elements_per_xword : 0;
+
+  lmc::check_block_size(engine_kv_format, block_size);
+  lmc::check_head_size(engine_kv_format, head_size_xword);
+
+  // Fused packs K+V in the trailing dim (kv_size == 1, like MLA): single pass.
+  int k_or_v_size =
+      (::is_mla(engine_kv_format) || ::is_fused_packed(engine_kv_format)) ? 1
+                                                                          : 2;
+
+  dim3 grid(num_transfer_tokens, num_layers, k_or_v_size);
+  dim3 block(std::min(num_xwords, 128));
+
+  const at::cuda::OptionalCUDAGuard device_guard(paged_memory_device);
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  if (direction == TransferDirection::H2D) {
+    switch (engine_kv_format) {
+      case EngineKVFormat::NB_NL_TWO_BS_NH_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false, EngineKVFormat::NB_NL_TWO_BS_NH_HS);
+        break;
+      case EngineKVFormat::NL_X_TWO_NB_BS_NH_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_TWO_NB_BS_NH_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_TWO_BS_NH_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_NB_TWO_BS_NH_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_BS_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false, EngineKVFormat::NL_X_NB_BS_HS);
+        break;
+      case EngineKVFormat::NL_X_NBBS_ONE_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false, EngineKVFormat::NL_X_NBBS_ONE_HS);
+        break;
+      case EngineKVFormat::NL_X_TWO_NB_NH_BS_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_TWO_NB_NH_BS_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_TWO_NH_BS_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_NB_TWO_NH_BS_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_NH_BS_TWO_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_NB_NH_BS_TWO_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_BS_NH_TWO_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_NB_BS_NH_TWO_HS);
+        break;
+      default:
+        throw std::runtime_error("Unsupported EngineKVFormat");
+    }
+  } else {
+    switch (engine_kv_format) {
+      case EngineKVFormat::NB_NL_TWO_BS_NH_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true, EngineKVFormat::NB_NL_TWO_BS_NH_HS);
+        break;
+      case EngineKVFormat::NL_X_TWO_NB_BS_NH_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_TWO_NB_BS_NH_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_TWO_BS_NH_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_NB_TWO_BS_NH_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_BS_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true, EngineKVFormat::NL_X_NB_BS_HS);
+        break;
+      case EngineKVFormat::NL_X_NBBS_ONE_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true, EngineKVFormat::NL_X_NBBS_ONE_HS);
+        break;
+      case EngineKVFormat::NL_X_TWO_NB_NH_BS_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_TWO_NB_NH_BS_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_TWO_NH_BS_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_NB_TWO_NH_BS_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_NH_BS_TWO_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_NB_NH_BS_TWO_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_BS_NH_TWO_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_NB_BS_NH_TWO_HS);
+        break;
+      default:
+        throw std::runtime_error("Unsupported EngineKVFormat");
+    }
+  }
+}
+
+#undef LAUNCH_KERNEL_WITH_FORMAT
+
+/**
+ * @see multi_layer_kv_transfer_templated
+ */
+void multi_layer_kv_transfer(
+    torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
+    const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
+    const int page_buffer_size, const TransferDirection direction,
+    const EngineKVFormat engine_kv_format, const int block_size,
+    const int head_size, const int skip_prefix_n_tokens) {
+  int num_origin_elements = key_value.size(3);
+  int copy_size = num_origin_elements * key_value.element_size();
+#ifndef LAUNCH_MULTI_LAYER_KV_TRANSFER
+  #define LAUNCH_MULTI_LAYER_KV_TRANSFER(type)                          \
+    do {                                                                \
+      multi_layer_kv_transfer_templated<type>(                          \
+          key_value, key_value_ptrs, slot_mapping, paged_memory_device, \
+          page_buffer_size, direction, engine_kv_format, block_size,    \
+          head_size, skip_prefix_n_tokens);                             \
+    } while (0)
+#endif
+  if (copy_size % 8 == 0) {
+    LAUNCH_MULTI_LAYER_KV_TRANSFER(int64_t);
+  } else if (copy_size % 4 == 0) {
+    LAUNCH_MULTI_LAYER_KV_TRANSFER(int32_t);
+  } else if (copy_size % 2 == 0) {
+    LAUNCH_MULTI_LAYER_KV_TRANSFER(int16_t);
+  } else {
+    LAUNCH_MULTI_LAYER_KV_TRANSFER(int8_t);
+  }
+#undef LAUNCH_MULTI_LAYER_KV_TRANSFER
+}
+
+/**
+ * Quickly offload KV cache from SGLang paged memory to the offloading buffer
+ * Processes all the layers at the same time
+ *
+ * Each layer in SGLang's K/V buffer has a shape of
+ * [PAGE_BUFFER_SIZE, num_heads*head_size]
+ *
+ * Each thread block processes the copy for a token
+ * The grid size should be (num_tokens, num_layers, 2)
+ *
+ * Therefore:
+ *  - k/v -- block.z
+ *  - layer id -- block.y
+ *  - token id -- block.x
+ *  - offset within a token -- thread.x
+ *
+ * The function does:
+ * slot_id = slot_mapping[block.x]
+ * key_value[block.z, block.y, block.x, thread.x] = ptrs[block.y][block.z,
+ * slot_id, thread.x]
+ *
+ * Param:
+ *  - direction: H2D  means LMCache to PagedBuffer, D2H  means PagedBuffer to
+ * LMCache
+ */
+void multi_layer_kv_transfer_unilateral(
+    torch::Tensor&
+        key_value,  // [2, num_layer, num_tokens, num_heads*head_size] for
+                    // flash_attn [1, num_layer, num_tokens, aligned_head_size]
+                    // for MLA key/value must be on gpu/pinned cpu
+
+    const torch::Tensor& key_value_ptrs,  // [num_layers*2]
+    const torch::Tensor& slot_mapping,    // [num_tokens],
+    const torch::Device& paged_memory_device, const int page_buffer_size,
+    const TransferDirection direction, const EngineKVFormat engine_kv_format) {
+  const bool use_mla = ::is_mla(engine_kv_format);
+  // MLA case collapses back to multi_layer_kv_transfer
+  // (vLLM and SGLang indexing are compatible)
+  if (use_mla) {
+    return multi_layer_kv_transfer(key_value, key_value_ptrs, slot_mapping,
+                                   paged_memory_device, page_buffer_size,
+                                   direction, engine_kv_format);
+  }
+
+  int64_t* key_value_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_value);
+  int64_t** page_buffer_ptrs =
+      get_kernel_ptr<int64_t*, const torch::Tensor>(key_value_ptrs);
+  const int64_t* slot_mapping_ptr =
+      get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
+
+  int num_layers = key_value.size(1);
+  int num_tokens = slot_mapping.size(0);
+  int num_origin_elements = key_value.size(3);
+  int elements_per_qword = 8 / key_value.element_size();
+  int num_qwords = num_origin_elements / elements_per_qword;
+
+  int k_or_v_size = 2;
+
+  dim3 grid(key_value.size(2), key_value.size(1), k_or_v_size);
+  dim3 block(std::min(num_qwords, 128));
+
+  const at::cuda::OptionalCUDAGuard device_guard(paged_memory_device);
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  if (direction == TransferDirection::H2D) {
+    lmc::load_and_reshape_multi_layer_kernel_unilateral<int64_t, false>
+        <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
+                                     slot_mapping_ptr, num_qwords, num_tokens,
+                                     num_layers, page_buffer_size);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  } else {
+    lmc::load_and_reshape_multi_layer_kernel_unilateral<int64_t, true>
+        <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
+                                     slot_mapping_ptr, num_qwords, num_tokens,
+                                     num_layers, page_buffer_size);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+}
+
+void single_layer_kv_transfer(
+    // torch::Tensor& lmc_key_cache,  // [num_tokens, num_heads*head_size]
+    //  key/value must be on gpu/pinned cpu
+    // torch::Tensor& lmc_value_cache,  // [num_tokens, num_heads*head_size]
+
+    torch::Tensor& lmc_key_value_cache,  // [num_tokens, 2, num_heads*head_size]
+                                         // or
+                                         // [2, num_tokens, num_heads*head_size]
+                                         // or for MLA:
+                                         // [num_tokens, aligned_head_size]
+
+    // torch::Tensor&
+    //     vllm_key_cache,  // [num_blocks, block_size, num_heads, head_size]
+    // torch::Tensor&
+    //     vllm_value_cache,  // [num_blocks, block_size, num_heads, head_size]
+    //  key_cache/value_cache must be on gpu
+    torch::Tensor&
+        vllm_key_value_cache,  // NHD: [2, num_blocks, block_size, num_heads,
+                               //       head_size] for flash attention
+                               //      [num_blocks, 2, block_size, num_heads,
+                               //       head_size] for flash infer
+                               // HND: [2, num_blocks, num_heads, block_size,
+                               //       head_size] for flash attention
+                               //      [num_blocks, 2, num_heads, block_size,
+                               //       head_size] for flash infer
+                               // MLA: [num_blocks, block_size, head_size]
+
+    torch::Tensor& slot_mapping,  // [num_tokens]
+    const TransferDirection direction, const EngineKVFormat engine_kv_format,
+    const bool token_major  // true: lmc_key_value_cache is
+                            // [num_tokens, 2, num_heads*head_size]
+                            // false: lmc_key_value_cache is
+                            // [2, num_tokens, num_heads*head_size]
+) {
+  // int64_t* lmc_key_cache_ptr = get_kernel_ptr<int64_t,
+  // torch::Tensor>(lmc_key_cache); int64_t* lmc_value_cache_ptr =
+  // get_kernel_ptr<int64_t, torch::Tensor>(lmc_value_cache);
+  int64_t* lmc_key_value_cache_ptr =
+      get_kernel_ptr<int64_t, torch::Tensor>(lmc_key_value_cache);
+
+  int64_t* vllm_key_value_cache_ptr =
+      get_kernel_ptr<int64_t, torch::Tensor>(vllm_key_value_cache);
+  // int64_t* vllm_value_cache_ptr =
+  //     get_kernel_ptr<int64_t, torch::Tensor>(vllm_value_cache);
+
+  const int64_t* slot_mapping_ptr =
+      get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
+
+  int elements_per_entry = 8 / vllm_key_value_cache.element_size();
+
+  int num_tokens = slot_mapping.size(0);
+  int num_heads;
+  int head_size_in_64bit;
+  int block_size;
+
+  const bool use_mla = ::is_mla(engine_kv_format);
+  const bool hnd_layout = lmc::is_hnd(engine_kv_format);
+
+  if (use_mla) {
+    // MLA format: [num_blocks, block_size, head_size]
+    num_heads = 1;
+    block_size = vllm_key_value_cache.size(1);
+    head_size_in_64bit = vllm_key_value_cache.size(2) / elements_per_entry;
+  } else if (hnd_layout) {
+    // HND format: [..., num_heads, block_size, head_size]
+    num_heads = vllm_key_value_cache.size(2);
+    block_size = vllm_key_value_cache.size(3);
+    head_size_in_64bit = vllm_key_value_cache.size(4) / elements_per_entry;
+  } else {
+    // NHD format: [..., block_size, num_heads, head_size]
+    block_size = vllm_key_value_cache.size(2);
+    num_heads = vllm_key_value_cache.size(3);
+    head_size_in_64bit = vllm_key_value_cache.size(4) / elements_per_entry;
+  }
+
+  lmc::check_block_size(engine_kv_format, block_size);
+  lmc::check_head_size(engine_kv_format, head_size_in_64bit);
+
+  int lmc_stride;
+  int lmc_value_offset;
+  if (use_mla) {
+    // MLA format: [num_tokens, aligned_head_size]
+    lmc_stride = lmc_key_value_cache.stride(0) / elements_per_entry;
+    lmc_value_offset = 0;  // No separate K/V for MLA
+  } else if (token_major) {
+    lmc_stride = lmc_key_value_cache.stride(0) / elements_per_entry;
+    lmc_value_offset = lmc_key_value_cache.stride(1) / elements_per_entry;
+  } else {
+    lmc_stride = lmc_key_value_cache.stride(1) / elements_per_entry;
+    lmc_value_offset = lmc_key_value_cache.stride(0) / elements_per_entry;
+  }
+
+  int vllm_block_key_stride_in_64bit;
+  int vllm_value_offset;
+  if (use_mla) {
+    // MLA format: [num_blocks, block_size, head_size]
+    vllm_block_key_stride_in_64bit =
+        vllm_key_value_cache.stride(0) / elements_per_entry;
+    vllm_value_offset = 0;  // No separate K/V for MLA
+  } else if (engine_kv_format == EngineKVFormat::NL_X_TWO_NB_BS_NH_HS ||
+             engine_kv_format == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS) {
+    vllm_block_key_stride_in_64bit =
+        vllm_key_value_cache.stride(1) / elements_per_entry;
+    vllm_value_offset = vllm_key_value_cache.stride(0) / elements_per_entry;
+  } else {  // engine_kv_format == EngineKVFormat::NL_X_NB_TWO_BS_NH_HS
+    vllm_block_key_stride_in_64bit =
+        vllm_key_value_cache.stride(0) / elements_per_entry;
+    vllm_value_offset = vllm_key_value_cache.stride(1) / elements_per_entry;
+  }
+
+  // int block_stride_in_64bit = vllm_key_cache.stride(0) / elements_per_entry;
+  // TORCH_CHECK(vllm_key_cache.stride(0) == vllm_value_cache.stride(0));
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min(num_heads * head_size_in_64bit, 128));
+  const at::cuda::OptionalCUDAGuard device_guard(
+      device_of(vllm_key_value_cache));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  // Dispatch to the appropriate template specialization based on EngineKVFormat
+#define LAUNCH_SINGLE_LAYER_KERNEL(FORMAT)                                     \
+  lmc::single_layer_kv_transfer_kernel<int64_t, FORMAT>                        \
+      <<<grid, block, 0, stream>>>(                                            \
+          lmc_key_value_cache_ptr, vllm_key_value_cache_ptr, slot_mapping_ptr, \
+          vllm_block_key_stride_in_64bit, vllm_value_offset, lmc_stride,       \
+          lmc_value_offset, num_heads, head_size_in_64bit, block_size,         \
+          direction);                                                          \
+  break;
+
+  switch (engine_kv_format) {
+    case EngineKVFormat::NL_X_NB_BS_HS:
+      LAUNCH_SINGLE_LAYER_KERNEL(EngineKVFormat::NL_X_NB_BS_HS)
+    case EngineKVFormat::NL_X_TWO_NB_BS_NH_HS:
+      LAUNCH_SINGLE_LAYER_KERNEL(EngineKVFormat::NL_X_TWO_NB_BS_NH_HS)
+    case EngineKVFormat::NL_X_NB_TWO_BS_NH_HS:
+      LAUNCH_SINGLE_LAYER_KERNEL(EngineKVFormat::NL_X_NB_TWO_BS_NH_HS)
+    case EngineKVFormat::NL_X_TWO_NB_NH_BS_HS:
+      LAUNCH_SINGLE_LAYER_KERNEL(EngineKVFormat::NL_X_TWO_NB_NH_BS_HS)
+    case EngineKVFormat::NL_X_NB_TWO_NH_BS_HS:
+      LAUNCH_SINGLE_LAYER_KERNEL(EngineKVFormat::NL_X_NB_TWO_NH_BS_HS)
+    default:
+      TORCH_CHECK(false,
+                  "Unsupported EngineKVFormat for single_layer_kv_transfer: ",
+                  static_cast<int>(engine_kv_format));
+  }
+#undef LAUNCH_SINGLE_LAYER_KERNEL
+}
+
+void load_and_reshape_flash(
+    torch::Tensor&
+        key_value,  // [2, num_layer, num_tokens, num_heads*head_size]
+                    // key/value must be on gpu/pinned cpu
+
+    torch::Tensor& key_cache,  // [num_blocks, block_size, num_heads, head_size]
+    torch::Tensor&
+        value_cache,  // [num_blocks, block_size, num_heads, head_size]
+                      // key_cache/value_cache must be on gpu
+    torch::Tensor& slot_mapping,  // [num_tokens],
+    const int layer_idx) {
+  int64_t* key_value_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_value);
+
+  int64_t* key_cache_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_cache);
+  int64_t* value_cache_ptr =
+      get_kernel_ptr<int64_t, torch::Tensor>(value_cache);
+
+  const int64_t* slot_mapping_ptr =
+      get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
+
+  int elements_per_entry = 8 / key_cache.element_size();
+
+  int num_tokens = slot_mapping.size(0);
+  int num_heads = key_cache.size(2);
+  int head_size_in_64bit = key_cache.size(3) / elements_per_entry;
+
+  int block_size = key_cache.size(1);
+
+  int key_value_stride = key_value.stride(2) / elements_per_entry;
+
+  int num_layers = key_value.size(1);
+  int key_layer_offset = layer_idx * key_value.stride(1) / elements_per_entry;
+  int value_layer_offset =
+      (layer_idx + num_layers) * key_value.stride(1) / elements_per_entry;
+
+  int block_stride_in_64bit = key_cache.stride(0) / elements_per_entry;
+  TORCH_CHECK(key_cache.stride(0) == value_cache.stride(0));
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min(num_heads * head_size_in_64bit, 128));
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(key_cache));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  lmc::load_and_reshape_flash_kernel<int64_t><<<grid, block, 0, stream>>>(
+      key_value_ptr, key_cache_ptr, value_cache_ptr, slot_mapping_ptr,
+      block_stride_in_64bit, key_value_stride, num_heads, head_size_in_64bit,
+      block_size, key_layer_offset, value_layer_offset);
+}
+
+void reshape_and_cache_back_flash(
+    torch::Tensor&
+        key_value,  // [2, num_layer, num_tokens, num_heads*head_size]
+                    // key/value must be on gpu/pinned cpu
+
+    torch::Tensor& key_cache,  // [num_blocks, block_size, num_heads, head_size]
+    torch::Tensor&
+        value_cache,  // [num_blocks, block_size, num_heads, head_size]
+                      // key_cache/value_cache must be on gpu
+    torch::Tensor& slot_mapping,  // [num_tokens]
+    const int layer_idx) {
+  int64_t* key_cache_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_cache);
+  int64_t* value_cache_ptr =
+      get_kernel_ptr<int64_t, torch::Tensor>(value_cache);
+
+  int64_t* key_value_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_value);
+
+  const int64_t* slot_mapping_ptr =
+      get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
+
+  int elements_per_entry = 8 / key_cache.element_size();
+
+  int num_tokens = slot_mapping.size(0);
+  int num_heads = key_cache.size(2);
+  int head_size_in_64bit = key_cache.size(3) / elements_per_entry;
+
+  int block_size = key_cache.size(1);
+
+  int key_value_stride = key_value.stride(2) / elements_per_entry;
+
+  int num_layers = key_value.size(1);
+  int key_layer_offset = layer_idx * key_value.stride(1) / elements_per_entry;
+  int value_layer_offset =
+      (layer_idx + num_layers) * key_value.stride(1) / elements_per_entry;
+
+  int block_stride_in_64bit = key_cache.stride(0) / elements_per_entry;
+  TORCH_CHECK(key_cache.stride(0) == value_cache.stride(0));
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min(num_heads * head_size_in_64bit, 128));
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(key_cache));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  lmc::reshape_and_cache_back_flash_kernel<int64_t><<<grid, block, 0, stream>>>(
+      key_value_ptr, key_cache_ptr, value_cache_ptr, slot_mapping_ptr,
+      block_stride_in_64bit, key_value_stride, num_heads, head_size_in_64bit,
+      block_size, key_layer_offset, value_layer_offset);
+}
+
+void single_layer_kv_transfer_sgl(
+    // torch::Tensor& lmc_key_cache,  // [num_tokens, num_heads*head_size]
+    //  key/value must be on gpu/pinned cpu
+    // torch::Tensor& lmc_value_cache,  // [num_tokens, num_heads*head_size]
+
+    torch::Tensor& lmc_key_value_cache,  // [num_tokens, 2, num_heads*head_size]
+                                         // or
+                                         // [2, num_tokens, num_heads*head_size]
+
+    torch::Tensor&
+        sgl_key_cache,  // [num_blocks, block_size, num_heads, head_size]
+    torch::Tensor&
+        sgl_value_cache,  // [num_blocks, block_size, num_heads, head_size]
+                          // key_cache/value_cache must be on gpu
+    torch::Tensor& slot_mapping,  // [num_tokens]
+    const TransferDirection direction,
+    const bool token_major  // true: lmc_key_value_cache is
+                            // [num_tokens, 2, num_heads*head_size]
+                            // false: lmc_key_value_cache is
+                            // [2, num_tokens, num_heads*head_size]
+) {
+  // int64_t* lmc_key_cache_ptr = get_kernel_ptr<int64_t,
+  // torch::Tensor>(lmc_key_cache); int64_t* lmc_value_cache_ptr =
+  // get_kernel_ptr<int64_t, torch::Tensor>(lmc_value_cache);
+  int64_t* lmc_key_value_cache_ptr =
+      get_kernel_ptr<int64_t, torch::Tensor>(lmc_key_value_cache);
+
+  int64_t* sgl_key_cache_ptr =
+      get_kernel_ptr<int64_t, torch::Tensor>(sgl_key_cache);
+  int64_t* sgl_value_cache_ptr =
+      get_kernel_ptr<int64_t, torch::Tensor>(sgl_value_cache);
+
+  const int64_t* slot_mapping_ptr =
+      get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
+
+  int elements_per_entry = 8 / sgl_key_cache.element_size();
+
+  int num_tokens = slot_mapping.size(0);
+  int num_heads = sgl_key_cache.size(2);
+  int head_size_in_64bit = sgl_key_cache.size(3) / elements_per_entry;
+
+  int block_size = sgl_key_cache.size(1);
+
+  int lmc_stride;
+  int lmc_value_offset;
+  if (token_major) {
+    lmc_stride = lmc_key_value_cache.stride(0) / elements_per_entry;
+    lmc_value_offset = lmc_key_value_cache.stride(1) / elements_per_entry;
+  } else {
+    lmc_stride = lmc_key_value_cache.stride(1) / elements_per_entry;
+    lmc_value_offset = lmc_key_value_cache.stride(0) / elements_per_entry;
+  }
+
+  int block_stride_in_64bit = sgl_key_cache.stride(0) / elements_per_entry;
+  TORCH_CHECK(sgl_key_cache.stride(0) == sgl_value_cache.stride(0));
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min(num_heads * head_size_in_64bit, 128));
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(sgl_key_cache));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  lmc::single_layer_kv_transfer_sgl_kernel<int64_t><<<grid, block, 0, stream>>>(
+      lmc_key_value_cache_ptr, sgl_key_cache_ptr, sgl_value_cache_ptr,
+      slot_mapping_ptr, block_stride_in_64bit, lmc_stride, lmc_value_offset,
+      num_heads, head_size_in_64bit, block_size, direction);
+}
+
+/**
+ * Perform asynchronous memory copy between lmcache host buffer (memory obj)
+ * and a device buffer.
+ * The copy will be performed asynchronously on the current CUDA stream.
+ * They copy will be split into multiple smaller copies based on the host buffer
+ * offset and host buffer alignment requirements.
+ *
+ * @param dest Destination pointer (device or host)
+ * @param src Source pointer (device or host)
+ * @param nbytes Number of bytes to copy
+ * @param direction H2D or D2H
+ * @param host_buffer_offset the virtual offset in the lmcache memory allocator
+ * @param host_buffer_alignments the alignment (i.e., cudaHostRegister
+ * granularity) requirement of the host buffer. Must be power of two.
+ */
+void lmcache_memcpy_async(uintptr_t dest, uintptr_t src, size_t nbytes,
+                          TransferDirection direction,
+                          size_t host_buffer_offset,
+                          size_t host_buffer_alignments) {
+  // Check that host_buffer_alignments is power of two
+  TORCH_CHECK((host_buffer_alignments & (host_buffer_alignments - 1)) == 0,
+              "host_buffer_alignments must be power of two");
+
+  size_t offset = 0;
+  const size_t mask = host_buffer_alignments - 1;
+  cudaMemcpyKind kind = (direction == TransferDirection::H2D)
+                            ? cudaMemcpyHostToDevice
+                            : cudaMemcpyDeviceToHost;
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  while (offset < nbytes) {
+    size_t current_src = src + offset;
+    size_t current_dest = dest + offset;
+
+    size_t aligned_area_end =
+        ((offset + host_buffer_offset) & ~mask) + host_buffer_alignments;
+    // Use std::min<size_t> so HIP's overload set cannot silently narrow
+    // these values to int and produce a garbage length past the 2 GB mark.
+    size_t real_end =
+        std::min<size_t>(host_buffer_offset + nbytes, aligned_area_end);
+    size_t max_nbytes = real_end - offset - host_buffer_offset;
+
+    CHECK_CUDA_CALL(cudaMemcpyAsync(reinterpret_cast<void*>(current_dest),
+                                    reinterpret_cast<const void*>(current_src),
+                                    max_nbytes, kind, stream));
+
+    offset += max_nbytes;
+  }
+}

--- a/maru_kv_ops/csrc/mem_kernels.cuh
+++ b/maru_kv_ops/csrc/mem_kernels.cuh
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <torch/all.h>
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/util/Exception.h>
+#include "kv_transfer_types.h"
+
+void multi_layer_kv_transfer(
+    torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
+    const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
+    const int page_buffer_size, const TransferDirection direction,
+    const EngineKVFormat engine_kv_format, const int block_size = 0,
+    const int head_size = 0, const int skip_prefix_n_tokens = 0);
+
+// collapses to multi_layer_kv_transfer for MLA
+void multi_layer_kv_transfer_unilateral(
+    torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
+    const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
+    const int page_buffer_size, const TransferDirection direction,
+    const EngineKVFormat engine_kv_format);
+
+void single_layer_kv_transfer(torch::Tensor& lmc_key_value_cache,
+                              torch::Tensor& vllm_key_value_cache,
+                              torch::Tensor& slot_mapping,
+                              const TransferDirection direction,
+                              const EngineKVFormat engine_kv_format,
+                              const bool token_major = false);
+
+void single_layer_kv_transfer_sgl(torch::Tensor& lmc_key_value_cache,
+                                  torch::Tensor& sgl_key_cache,
+                                  torch::Tensor& sgl_value_cache,
+                                  torch::Tensor& slot_mapping,
+                                  const TransferDirection direction,
+                                  const bool token_major = false);
+
+void lmcache_memcpy_async(uintptr_t dest, uintptr_t src, size_t nbytes,
+                          TransferDirection direction,
+                          size_t host_buffer_offset,
+                          size_t host_buffer_alignments);
+
+// deprecated / unused except in unit tests
+void load_and_reshape_flash(torch::Tensor& key_value, torch::Tensor& key_cache,
+                            torch::Tensor& value_cache,
+                            torch::Tensor& slot_mapping, const int layer_idx);
+
+// deprecated / unused except in unit tests
+void reshape_and_cache_back_flash(torch::Tensor& key_value,
+                                  torch::Tensor& key_cache,
+                                  torch::Tensor& value_cache,
+                                  torch::Tensor& slot_mapping,
+                                  const int layer_idx);

--- a/maru_kv_ops/csrc/mp_mem_kernels.cu
+++ b/maru_kv_ops/csrc/mp_mem_kernels.cu
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mp_mem_kernels.cuh"
+
+namespace {
+
+/**
+ * Key logic in the kernel implementation:
+ * 1. Each thread block is for (BS, NH, HS) part (i.e., a single block in the
+ * paged buffer)
+ * 2. Within a thread block, each warp is for a single head. Number of warps
+ * in a thread block is equal to the number of heads (NH).
+ * 3. Within a thread block, we do the loop over the BS (i.e., number of tokens
+ * in the block) dimension.
+ * 4. The grid will take over (2, NB, NL) dimensions. No matter what the actual
+ * layout in memory is, we will calculate the global offset for the start of the
+ * block
+ * 5. For LMCache, we assume it is always using 2LTD layout, e.g.,
+ * [2, L, 256, NH * HS], where 256 means that 256 tokens
+ */
+
+/**
+ * Calculate the offset for the current block in the paged buffer
+ */
+template <typename ScalarType, EngineKVFormat format>
+__device__ inline size_t calculate_engine_global_offset(
+    const int k_or_v, const int engine_block_idx, const int layer_idx,
+    const PageBufferShapeDesc shape_desc) {
+  size_t scalars_per_block = shape_desc.scalars_per_block<ScalarType>();
+  if constexpr (format == EngineKVFormat::NB_NL_TWO_BS_NH_HS) {
+    // Cross-layer: single tensor [NB, NL, 2, BS, NH, HS]
+    return k_or_v * scalars_per_block +
+           layer_idx * shape_desc.kv_size * scalars_per_block +
+           engine_block_idx * shape_desc.kv_size * scalars_per_block *
+               shape_desc.nl;
+  } else if constexpr (format == EngineKVFormat::NL_X_TWO_NB_BS_NH_HS) {
+    // Normal: L tensors [2, NB, BS, NH, HS]
+    return engine_block_idx * scalars_per_block +
+           k_or_v * shape_desc.nb * scalars_per_block;
+  } else if constexpr (format == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS) {
+    // Normal HND: L tensors [2, NB, NH, BS, HS]
+    return engine_block_idx * scalars_per_block +
+           k_or_v * shape_desc.nb * scalars_per_block;
+  } else if constexpr (format == EngineKVFormat::NL_X_NB_TWO_BS_NH_HS) {
+    // Flash Infer: L tensors [NB, 2, BS, NH, HS]
+    return engine_block_idx * shape_desc.kv_size * scalars_per_block +
+           k_or_v * scalars_per_block;
+  } else if constexpr (format == EngineKVFormat::NL_X_NB_TWO_NH_BS_HS) {
+    // Flash Infer HND: L tensors [NB, 2, NH, BS, HS]
+    return engine_block_idx * shape_desc.kv_size * scalars_per_block +
+           k_or_v * scalars_per_block;
+  } else if constexpr (format == EngineKVFormat::NL_X_NB_BS_HS) {
+    // MLA: L tensors [NB, BS, HS]
+    return engine_block_idx * scalars_per_block;
+  } else if constexpr (format == EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS) {
+    // SGLang MHA (in-process): 2L tensors [NBBS, NH, HS]
+    return engine_block_idx * scalars_per_block;
+  } else if constexpr (format == EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS) {
+    // SGLang MHA (MP daemon): 2L tensors [NB, BS, NH, HS]
+    return engine_block_idx * scalars_per_block;
+  } else if constexpr (format == EngineKVFormat::NL_X_NBBS_ONE_HS) {
+    // SGLang MLA: L tensors [NBBS, 1, HS]
+    return engine_block_idx * scalars_per_block;
+  } else if constexpr (format == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS) {
+    // Fused-K/V HND: L tensors [NB, NH, BS, 2*HS], handled like
+    // NL_X_TWO_NB_NH_BS_HS but with an empty K/V axis: the desc carries
+    // kv_size == 1 and hs == 2 * head_size, so k_or_v is always 0 and each
+    // head copy moves the packed K+V pair.
+    return engine_block_idx * scalars_per_block;
+  } else if constexpr (format == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS) {
+    // Fused-K/V NHD: L tensors [NB, BS, NH, 2*HS]; same empty K/V axis as
+    // NL_X_NB_NH_BS_TWO_HS (kv_size == 1, hs == 2 * head_size), tokens
+    // before heads within a block.
+    return engine_block_idx * scalars_per_block;
+  } else if constexpr (format == EngineKVFormat::NB_NL_TWO_NH_BS_HS) {
+    // TRT-LLM cross-layer HND: single tensor [NB, NL, 2, NH, BS, HS]
+    // same block-level strides as NB_NL_TWO_BS_NH_HS
+    return k_or_v * scalars_per_block +
+           layer_idx * shape_desc.kv_size * scalars_per_block +
+           engine_block_idx * shape_desc.kv_size * scalars_per_block *
+               shape_desc.nl;
+  }
+}
+
+/**
+ * Calculate the offset for the current token against the start
+ * of the block in the paged buffer.
+ */
+template <typename ScalarType, EngineKVFormat format>
+__device__ inline size_t calculate_engine_local_offset(
+    const int token_offset, const int head_idx,
+    const PageBufferShapeDesc shape_desc) {
+  size_t scalars_per_head = shape_desc.scalars_per_head<ScalarType>();
+  size_t scalars_per_token = shape_desc.scalars_per_token<ScalarType>();
+  if constexpr (format == EngineKVFormat::NB_NL_TWO_NH_BS_HS ||
+                format == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS ||
+                format == EngineKVFormat::NL_X_NB_TWO_NH_BS_HS ||
+                format == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS) {
+    // HND: [NH, BS, HS] — heads are outermost within a block
+    size_t scalars_per_head_block =
+        shape_desc.bs * scalars_per_head;  // BS * HS
+    return head_idx * scalars_per_head_block + token_offset * scalars_per_head;
+  } else {
+    // NHD: [BS, NH, HS] — tokens are outermost within a block
+    return head_idx * scalars_per_head + token_offset * scalars_per_token;
+  }
+}
+
+/**
+ * Calculate the global offset for the current `block` in the LMCache object.
+ * The `block` here is the memory region corresponding to a thread-block.
+ */
+template <typename ScalarType, EngineKVFormat format>
+__device__ inline size_t calculate_lmcache_global_offset(
+    const int k_or_v,
+    const int
+        token_offset_in_lmcache_object,  // 0~255 if LMCache chunk size is 256
+    const int layer_idx,
+    const int lmcache_chunk_size,  // e.g., 256
+    const PageBufferShapeDesc shape_desc) {
+  size_t scalars_per_token = shape_desc.scalars_per_token<ScalarType>();
+  // LMCache is using 2LTD all the times
+  return token_offset_in_lmcache_object * scalars_per_token +
+         layer_idx * lmcache_chunk_size * scalars_per_token +
+         k_or_v * shape_desc.nl * lmcache_chunk_size * scalars_per_token;
+}
+
+/**
+ * Calculate the local offset for the current token against the start of the
+ * block in the LMCache object.
+ */
+template <typename ScalarType, EngineKVFormat format>
+__device__ inline size_t calculate_lmcache_local_offset(
+    const int token_offset, const int head_idx,
+    const PageBufferShapeDesc shape_desc) {
+  size_t scalars_per_head = shape_desc.scalars_per_head<ScalarType>();
+  size_t scalars_per_token = shape_desc.scalars_per_token<ScalarType>();
+  return head_idx * scalars_per_head + token_offset * scalars_per_token;
+}
+
+__device__ inline uint4 ld_cs(const uint4* addr) {
+#ifdef __CUDA_ARCH__
+  uint4 val;
+  asm volatile("ld.global.cs.v4.u32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)
+               : "l"(addr));
+  return val;
+#else
+  return *addr;
+#endif
+}
+
+__device__ inline void st_cs(uint4* addr, uint4 val) {
+#ifdef __CUDA_ARCH__
+  asm volatile("st.global.cs.v4.u32 [%0], {%1, %2, %3, %4};"
+               :
+               : "l"(addr), "r"(val.x), "r"(val.y), "r"(val.z), "r"(val.w));
+#else
+  *addr = val;
+#endif
+}
+
+template <typename ScalarType>
+__device__ inline void warp_copy(ScalarType* __restrict__ dst,
+                                 const ScalarType* __restrict__ src,
+                                 size_t num_elements) {
+  int idx = threadIdx.x;
+  int stride = blockDim.x;
+  if constexpr (std::is_same_v<ScalarType, uint4>) {
+    for (size_t i = idx; i < num_elements; i += stride) {
+      st_cs(dst + i, ld_cs(src + i));
+    }
+  } else {
+    for (size_t i = idx; i < num_elements; i += stride) {
+      dst[i] = src[i];
+    }
+  }
+}
+
+template <typename ScalarType, bool lmcache_to_engine, EngineKVFormat format>
+__device__ void multi_layer_block_transfer_single_block(
+    ScalarType* __restrict__ lmcache_object,
+    ScalarType** __restrict__ paged_buffer_ptrs, const int engine_block_idx,
+    const int offset_in_lmcache_block, const PageBufferShapeDesc shape_desc,
+    const int lmcache_chunk_size  // e.g., 256, used to calculate global offset
+                                  // in LMCache object
+) {
+  const int head_idx = threadIdx.y;
+  const int k_or_v = blockIdx.x;
+  const int layer_idx = blockIdx.z;
+
+  const size_t engine_global_offset =
+      calculate_engine_global_offset<ScalarType, format>(
+          k_or_v, engine_block_idx, layer_idx, shape_desc);
+  const size_t lmcache_global_offset =
+      calculate_lmcache_global_offset<ScalarType, format>(
+          k_or_v, offset_in_lmcache_block, layer_idx, lmcache_chunk_size,
+          shape_desc);
+  ScalarType* paged_buffer_layer_ptr;
+  if constexpr (format == EngineKVFormat::NB_NL_TWO_BS_NH_HS ||
+                format == EngineKVFormat::NB_NL_TWO_NH_BS_HS) {
+    paged_buffer_layer_ptr = (ScalarType*)paged_buffer_ptrs[0];
+  } else if constexpr (format == EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS) {
+    // SGLang MHA (in-process): ptrs[0..NL-1] = K per layer, ptrs[NL..2NL-1] = V
+    // per layer
+    paged_buffer_layer_ptr =
+        (ScalarType*)paged_buffer_ptrs[k_or_v * shape_desc.nl + layer_idx];
+  } else if constexpr (format == EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS) {
+    // SGLang MHA (MP daemon): ptrs[0..NL-1] = K per layer, ptrs[NL..2NL-1] = V
+    // per layer
+    paged_buffer_layer_ptr =
+        (ScalarType*)paged_buffer_ptrs[k_or_v * shape_desc.nl + layer_idx];
+  } else {
+    paged_buffer_layer_ptr = (ScalarType*)paged_buffer_ptrs[layer_idx];
+  }
+
+  for (int token_offset = 0; token_offset < shape_desc.bs; ++token_offset) {
+    const size_t engine_local_offset =
+        calculate_engine_local_offset<ScalarType, format>(token_offset,
+                                                          head_idx, shape_desc);
+    const size_t lmcache_local_offset =
+        calculate_lmcache_local_offset<ScalarType, format>(
+            token_offset, head_idx, shape_desc);
+    ScalarType* engine_ptr =
+        paged_buffer_layer_ptr + engine_global_offset + engine_local_offset;
+    ScalarType* lmcache_ptr =
+        lmcache_object + lmcache_global_offset + lmcache_local_offset;
+    if constexpr (lmcache_to_engine) {
+      warp_copy<ScalarType>(engine_ptr, lmcache_ptr,
+                            shape_desc.scalars_per_head<ScalarType>());
+    } else {
+      warp_copy<ScalarType>(lmcache_ptr, engine_ptr,
+                            shape_desc.scalars_per_head<ScalarType>());
+    }
+  }
+}
+
+template <typename ScalarType, bool lmcache_to_engine, EngineKVFormat format>
+__global__ void multi_layer_block_transfer_kernel(
+    MemoryObj4<ScalarType> lmcache_objects,
+    ScalarType** __restrict__ paged_buffer_ptrs,
+    const int64_t* engine_block_ids,
+    const int num_blocks_per_object,  // e.g. 16 for lmcache chunk size =
+                                      // 256 and block size = 16
+    const PageBufferShapeDesc shape_desc,
+    const int lmcache_chunk_size,  // e.g., 256, used to calculate global offset
+                                   // in LMCache object
+    const int skip_prefix_n_blocks) {
+  // blockIdx.y spans all blocks across all objects (total_blocks).
+  // Derive which object and local block index from the flat index.
+  const int flat_block_idx = blockIdx.y;
+  if (flat_block_idx < skip_prefix_n_blocks) {
+    return;
+  }
+  const int obj_idx = flat_block_idx / num_blocks_per_object;
+  const int block_idx_in_object = flat_block_idx % num_blocks_per_object;
+
+  const int engine_block_idx = engine_block_ids[flat_block_idx];
+  multi_layer_block_transfer_single_block<ScalarType, lmcache_to_engine,
+                                          format>(
+      lmcache_objects.objects[obj_idx], paged_buffer_ptrs, engine_block_idx,
+      block_idx_in_object * shape_desc.bs,  // offset in LMCache object
+      shape_desc, lmcache_chunk_size);
+}
+
+#define LAUNCH_KERNEL(DIRECTION, FORMAT)                                 \
+  multi_layer_block_transfer_kernel<ScalarType, DIRECTION, FORMAT>       \
+      <<<grid, block, 0, stream>>>(lmcache_obj4, paged_buffer_ptrs,      \
+                                   block_ids_ptr, num_blocks_per_object, \
+                                   shape_desc, lmcache_chunk_size,       \
+                                   skip_prefix_n_blocks);                \
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+#define DISPATCH_FORMAT(DIRECTION)                                      \
+  switch (engine_kv_format) {                                           \
+    case EngineKVFormat::NB_NL_TWO_BS_NH_HS:                            \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NB_NL_TWO_BS_NH_HS);     \
+      break;                                                            \
+    case EngineKVFormat::NL_X_TWO_NB_BS_NH_HS:                          \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_TWO_NB_BS_NH_HS);   \
+      break;                                                            \
+    case EngineKVFormat::NL_X_TWO_NB_NH_BS_HS:                          \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_TWO_NB_NH_BS_HS);   \
+      break;                                                            \
+    case EngineKVFormat::NL_X_NB_TWO_BS_NH_HS:                          \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_NB_TWO_BS_NH_HS);   \
+      break;                                                            \
+    case EngineKVFormat::NL_X_NB_TWO_NH_BS_HS:                          \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_NB_TWO_NH_BS_HS);   \
+      break;                                                            \
+    case EngineKVFormat::NL_X_NB_BS_HS:                                 \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_NB_BS_HS);          \
+      break;                                                            \
+    case EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS:                         \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS);  \
+      break;                                                            \
+    case EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS:                        \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS); \
+      break;                                                            \
+    case EngineKVFormat::NL_X_NBBS_ONE_HS:                              \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_NBBS_ONE_HS);       \
+      break;                                                            \
+    case EngineKVFormat::NB_NL_TWO_NH_BS_HS:                            \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NB_NL_TWO_NH_BS_HS);     \
+      break;                                                            \
+    case EngineKVFormat::NL_X_NB_NH_BS_TWO_HS:                          \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_NB_NH_BS_TWO_HS);   \
+      break;                                                            \
+    case EngineKVFormat::NL_X_NB_BS_NH_TWO_HS:                          \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_NB_BS_NH_TWO_HS);   \
+      break;                                                            \
+    default:                                                            \
+      TORCH_CHECK(false, "Unsupported EngineKVFormat: ",                \
+                  static_cast<int>(engine_kv_format));                  \
+  }
+
+template <typename ScalarType>
+void multi_layer_block_kv_transfer_templated(
+    const torch::Tensor& paged_buffer_ptrs_tensor,
+    std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
+    const torch::Device& device, TransferDirection direction,
+    PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
+    EngineKVFormat engine_kv_format, int skip_prefix_n_blocks) {
+  // --- Validation ---
+  int num_objects = static_cast<int>(lmcache_objects_ptrs.size());
+  TORCH_CHECK(num_objects >= 1 && num_objects <= 4,
+              "Expected 1-4 LMCache objects, got ", num_objects);
+
+  int total_blocks = block_ids.size(0);
+  TORCH_CHECK(total_blocks % num_objects == 0, "block_ids length (",
+              total_blocks, ") must be divisible by num_objects (", num_objects,
+              ")");
+  int num_blocks_per_object = total_blocks / num_objects;
+
+  TORCH_CHECK(num_blocks_per_object * shape_desc.bs == lmcache_chunk_size,
+              "blocks_per_object * block_size (",
+              num_blocks_per_object * shape_desc.bs,
+              ") must equal lmcache_chunk_size (", lmcache_chunk_size, ")");
+
+  // --- Build MemoryObj4 ---
+  MemoryObj4<ScalarType> lmcache_obj4;
+  lmcache_obj4.num_objects = num_objects;
+  for (int i = 0; i < 4; ++i) {
+    lmcache_obj4.objects[i] =
+        (i < num_objects)
+            ? reinterpret_cast<ScalarType*>(lmcache_objects_ptrs[i])
+            : nullptr;
+  }
+
+  // --- Build paged buffer pointer array ---
+  ScalarType** paged_buffer_ptrs =
+      reinterpret_cast<ScalarType**>(paged_buffer_ptrs_tensor.data_ptr());
+
+  const at::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  // --- block_ids is a GPU int64 tensor, read directly ---
+  const int64_t* block_ids_ptr = block_ids.data_ptr<int64_t>();
+
+  // --- Grid and block dimensions ---
+  int elements_per_head = shape_desc.hs * shape_desc.element_size /
+                          static_cast<int>(sizeof(ScalarType));
+  int thread_dim_x = std::min(elements_per_head, 32);
+  int thread_dim_y = shape_desc.nh;
+
+  dim3 block(thread_dim_x, thread_dim_y);
+  dim3 grid(shape_desc.kv_size, total_blocks, shape_desc.nl);
+
+  if (direction == TransferDirection::H2D) {
+    DISPATCH_FORMAT(true);
+  } else {
+    DISPATCH_FORMAT(false);
+  }
+}
+
+#undef DISPATCH_FORMAT
+#undef LAUNCH_KERNEL
+
+}  // namespace
+
+#define LAUNCH_TEMPLATED(type)                                             \
+  do {                                                                     \
+    multi_layer_block_kv_transfer_templated<type>(                         \
+        paged_buffer_ptrs_tensor, lmcache_objects_ptrs, block_ids, device, \
+        direction, shape_desc, lmcache_chunk_size, engine_kv_format,       \
+        skip_prefix_n_blocks);                                             \
+  } while (0)
+
+void multi_layer_block_kv_transfer(
+    const torch::Tensor& paged_buffer_ptrs_tensor,
+    std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
+    const torch::Device& device, TransferDirection direction,
+    PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
+    EngineKVFormat engine_kv_format, int skip_prefix_n_blocks) {
+  int head_bytes = shape_desc.hs * shape_desc.element_size;
+  TORCH_CHECK(head_bytes % sizeof(uint16_t) == 0, "head_size * element_size (",
+              head_bytes, ") must be divisible by 2 for vectorized access");
+
+  if (head_bytes % sizeof(uint4) == 0) {
+    LAUNCH_TEMPLATED(uint4);  // 16 bytes per copy
+  } else if (head_bytes % sizeof(uint32_t) == 0) {
+    LAUNCH_TEMPLATED(uint32_t);  // 4 bytes per copy
+  } else {
+    LAUNCH_TEMPLATED(uint16_t);  // 2 bytes per copy (minimum granularity)
+  }
+}
+
+#undef LAUNCH_TEMPLATED
+
+void execute_object_group_transfer(
+    TransferDirection direction, const torch::Device& device,
+    size_t host_buffer_alignment,
+    const std::vector<KernelGroupSpec>& kernel_group_specs,
+    const std::vector<BatchStep>& batch_steps) {
+  // Set the device guard once for the whole plan so every staging copy and
+  // kernel launch below is enqueued on this device's current stream, in order.
+  const at::cuda::OptionalCUDAGuard device_guard(device);
+  const bool is_h2d = (direction == TransferDirection::H2D);
+  const auto int64_opts = at::TensorOptions().dtype(at::kLong).device(device);
+
+  const auto do_staging = [&](const std::vector<StagingCopy>& staging) {
+    for (const auto& copy : staging) {
+      lmcache_memcpy_async(copy.dest, copy.src, copy.nbytes, direction,
+                           copy.host_offset, host_buffer_alignment);
+    }
+  };
+
+  for (const auto& step : batch_steps) {
+    // H2D stages CPU->GPU temp buffers before the kernel reads them; D2H stages
+    // GPU->CPU after the kernel writes them. The per-step ordering must be
+    // preserved because temp buffers are reused across steps.
+    if (is_h2d) {
+      do_staging(step.staging);
+    }
+    for (const auto& launch : step.launches) {
+      TORCH_CHECK(
+          launch.group_idx >= 0 &&
+              launch.group_idx < static_cast<int>(kernel_group_specs.size()),
+          "LaunchVar.group_idx out of range: ", launch.group_idx);
+      const KernelGroupSpec& group = kernel_group_specs[launch.group_idx];
+      TORCH_CHECK(launch.num_objects >= 1 &&
+                      launch.num_objects <=
+                          static_cast<int>(group.lmcache_objects_ptrs.size()),
+                  "LaunchVar.num_objects (", launch.num_objects,
+                  ") exceeds available temp buffers (",
+                  group.lmcache_objects_ptrs.size(), ")");
+      // Bounds-check the block_ids slice before the kernel dereferences it on
+      // device: an out-of-range offset/length would otherwise be a silent
+      // out-of-bounds device read (CUDA fault or garbage), not a clean error.
+      TORCH_CHECK(launch.block_ids_offset >= 0,
+                  "LaunchVar.block_ids_offset must be non-negative, got ",
+                  launch.block_ids_offset);
+      TORCH_CHECK(launch.total_blocks >= 0,
+                  "LaunchVar.total_blocks must be non-negative, got ",
+                  launch.total_blocks);
+      TORCH_CHECK(launch.block_ids_offset + launch.total_blocks <=
+                      group.block_ids_capacity,
+                  "LaunchVar block_ids slice [", launch.block_ids_offset, ", ",
+                  launch.block_ids_offset + launch.total_blocks,
+                  ") exceeds block_ids capacity ", group.block_ids_capacity);
+
+      // Wrap the plan's pre-resolved raw device addresses as non-owning tensor
+      // views so we can reuse the existing multi_layer_block_kv_transfer entry
+      // point without touching any of its code. The backing storage is owned by
+      // the caller's tensors (kept alive for the duration of this call); these
+      // views only carry the pointer/shape each launch needs. Downstream only
+      // reads paged_buffer_ptrs_tensor.data_ptr() and block_ids.{data_ptr,
+      // size(0)}.
+      const uintptr_t block_ids_addr =
+          group.block_ids_base +
+          static_cast<uintptr_t>(launch.block_ids_offset) * sizeof(int64_t);
+      const at::Tensor paged_buffer_ptrs_tensor = at::from_blob(
+          reinterpret_cast<void*>(group.paged_buffer_ptrs), {1}, int64_opts);
+      const at::Tensor block_ids = at::from_blob(
+          reinterpret_cast<void*>(block_ids_addr),
+          {static_cast<int64_t>(launch.total_blocks)}, int64_opts);
+      std::vector<int64_t> lmcache_objects_ptrs(
+          group.lmcache_objects_ptrs.begin(),
+          group.lmcache_objects_ptrs.begin() + launch.num_objects);
+
+      multi_layer_block_kv_transfer(
+          paged_buffer_ptrs_tensor, std::move(lmcache_objects_ptrs), block_ids,
+          device, direction, group.shape_desc, group.lmcache_chunk_size,
+          group.engine_kv_format, launch.skip_prefix_n_blocks);
+    }
+    if (!is_h2d) {
+      do_staging(step.staging);
+    }
+  }
+}

--- a/maru_kv_ops/csrc/mp_mem_kernels.cuh
+++ b/maru_kv_ops/csrc/mp_mem_kernels.cuh
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "mem_kernels.cuh"  // TransferDirection, EngineKVFormat
+
+#include <c10/cuda/CUDAGuard.h>
+#include <cstdint>
+#include <vector>
+
+struct PageBufferShapeDesc {
+  int kv_size;       // 1 or 2
+  int nl;            // num layers
+  int nb;            // num blocks
+  int bs;            // block size
+  int nh;            // num heads
+  int hs;            // head size
+  int element_size;  // bytes (1 or 2)
+  // Physical per-block stride in source-dtype element units, used by
+  // formats whose dim-0 is the block axis to step over padding bytes
+  // (e.g. DeepSeek V4 compressor / indexer caches sharing a vLLM KV
+  // pool with larger attn groups, whose rows are padded up to the
+  // pool's max row width). 0 means "unset — fall back to the
+  // format-specific tight stride".
+  //
+  // CONTRACT: pass ``tensor.stride(0)`` verbatim. PyTorch stride
+  // semantics already absorb every inner-dim extent (including
+  // ``kv_size``), so DO NOT pre-multiply by any inner dim.
+  //
+  // Honoured today only by NL_X_NB_BS_HS (per-layer [NB, BS, HS],
+  // MLA). NL_X_NB_TWO_BS_NH_HS is restricted to the tight form
+  // upstream and leaves this field at 0; all other formats either
+  // pack non-block info into dim-0 or do not support dim-0 padding,
+  // and ignore this field.
+  int block_stride_elems;
+
+  template <typename ScalarType>
+  __host__ __device__ inline size_t scalars_per_head() const {
+    return hs * element_size / sizeof(ScalarType);
+  }
+
+  template <typename ScalarType>
+  __host__ __device__ inline size_t scalars_per_token() const {
+    return nh * hs * element_size / sizeof(ScalarType);
+  }
+
+  // Per (K or V) block step along dim-0, expressed in ``ScalarType``
+  // element units (the kernel's working dtype, e.g. uint4 / uint32_t /
+  // uint16_t). Returns the tight ``bs * nh * hs`` by default, or the
+  // physical ``block_stride_elems`` when dim-0 carries padding (today
+  // only NL_X_NB_BS_HS, see ``block_stride_elems`` above). Every
+  // ``calculate_engine_global_offset`` branch uses this as the dim-0
+  // step, so honouring padding here propagates to all formats without
+  // per-branch changes.
+  template <typename ScalarType>
+  __host__ __device__ inline size_t scalars_per_block() const {
+    const size_t elems = block_stride_elems > 0
+                             ? static_cast<size_t>(block_stride_elems)
+                             : static_cast<size_t>(bs) * nh * hs;
+    return elems * element_size / sizeof(ScalarType);
+  }
+};
+
+template <typename ScalarType>
+struct MemoryObj4 {
+  ScalarType* objects[4];
+  int num_objects;  // 0 - 4
+};
+
+// ---------------------------------------------------------------------------
+// Object-group transfer plan.
+//
+// A whole object group's transfer (all staging copies + all kernel launches) is
+// described as a plan on the Python side, then executed in a single native call
+// (execute_object_group_transfer) that releases the GIL once for the entire
+// burst instead of once per copy/launch. See the design in
+// docs/design/v1/multiprocess/modules/ and lmcache_driven_transfer.py.
+// ---------------------------------------------------------------------------
+
+// One asynchronous host<->device copy. `host_offset` is the host-side virtual
+// offset in the lmcache allocator (source for H2D, destination for D2H).
+struct StagingCopy {
+  uintptr_t dest;
+  uintptr_t src;
+  size_t nbytes;
+  size_t host_offset;
+};
+
+// One kernel launch within a batch step. The batch-invariant arguments live in
+// the referenced KernelGroupSpec; only these vary per (batch, kernel group).
+struct LaunchVar {
+  int group_idx;             // index into the plan's kernel_group_specs
+  int64_t block_ids_offset;  // element offset into the group's block_ids_base
+  int total_blocks;          // number of block ids for this launch
+  int num_objects;           // chunks in this batch (1-4)
+  int skip_prefix_n_blocks;
+};
+
+// One batch: its staging copies and kernel launches. For H2D the staging runs
+// before the launches, for D2H after; the executor preserves this ordering.
+struct BatchStep {
+  std::vector<StagingCopy> staging;
+  std::vector<LaunchVar> launches;
+};
+
+// Per-kernel-group invariants, resolved once on the Python side.
+struct KernelGroupSpec {
+  uintptr_t paged_buffer_ptrs;                // device ptr-array base address
+  std::vector<int64_t> lmcache_objects_ptrs;  // temp GPU buffer ptr per slot
+  PageBufferShapeDesc shape_desc;
+  int lmcache_chunk_size;
+  EngineKVFormat engine_kv_format;
+  uintptr_t block_ids_base;  // device int64* base; sliced via block_ids_offset
+  int64_t block_ids_capacity;  // total int64 elements behind block_ids_base;
+                               // bounds-checks each slice in the executor
+};
+
+/**
+ * Execute one object group's transfer plan on the current CUDA stream.
+ *
+ * Enqueues every staging copy and kernel launch described by `batch_steps`
+ * within a single GIL release (configured at the pybind layer), eliminating the
+ * per-copy/per-launch GIL handoffs of the equivalent Python loop. The device
+ * guard and stream are set once for the whole plan.
+ *
+ * @param direction            H2D (retrieve) or D2H (store), applied to all ops
+ * @param device               CUDA device of the transfer
+ * @param host_buffer_alignment Host buffer alignment for staging copies
+ *                              (power of two)
+ * @param kernel_group_specs   Per-kernel-group invariants
+ * @param batch_steps          Ordered per-batch staging + launch work
+ */
+void execute_object_group_transfer(
+    TransferDirection direction, const torch::Device& device,
+    size_t host_buffer_alignment,
+    const std::vector<KernelGroupSpec>& kernel_group_specs,
+    const std::vector<BatchStep>& batch_steps);
+
+/**
+ * Block-level multi-layer KV transfer between vLLM paged buffers and
+ * LMCache contiguous memory objects.
+ *
+ * @param paged_buffer_ptrs_tensor  GPU int64 tensor of data pointers into
+ *                                  vLLM paged buffers (one per tensor)
+ * @param lmcache_objects_ptrs      Raw pointers to LMCache memory objects
+ * @param block_ids                 GPU int64 tensor of block indices in vLLM
+ *                                  paged buffer
+ * @param device                    CUDA device of vLLM tensors
+ * @param direction                 H2D (LMCache->vLLM) or D2H (vLLM->LMCache)
+ * @param shape_desc                Shape descriptor for the paged buffer
+ * @param lmcache_chunk_size        Tokens per LMCache memory object
+ * @param engine_kv_format             EngineKVFormat identifier
+ * @param skip_prefix_n_blocks      Number of blocks to skip at the beginning
+ */
+void multi_layer_block_kv_transfer(
+    const torch::Tensor& paged_buffer_ptrs_tensor,
+    std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
+    const torch::Device& device, TransferDirection direction,
+    PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
+    EngineKVFormat engine_kv_format, int skip_prefix_n_blocks);

--- a/maru_kv_ops/csrc/pybind.cpp
+++ b/maru_kv_ops/csrc/pybind.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Python bindings for Maru's paged-KV placement kernels.
+//
+// The kernels themselves are vendored from LMCache (see ../VENDOR.md); this
+// binding layer is Maru's own and exposes only the entry points the Maru
+// connectors call. The unexposed kernels in the vendored translation units are
+// still compiled — they are left untouched so the vendored sources stay
+// byte-identical to their upstream revision, which is what makes a refresh a
+// plain file copy.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <torch/extension.h>
+
+#include "mem_kernels.cuh"
+#include "mp_mem_kernels.cuh"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(_C, m) {
+  m.doc() = "Maru paged-KV placement kernels";
+
+  py::enum_<TransferDirection>(m, "TransferDirection")
+      .value("H2D", TransferDirection::H2D)
+      .value("D2H", TransferDirection::D2H)
+      .export_values();
+
+  // The full format set is bound even though Maru's layout detection emits
+  // only the four rank-5 vLLM forms today: the enum is a plain header enum, a
+  // value costs nothing, and binding all of them keeps a format added by a
+  // future refresh usable without touching this file.
+  py::enum_<EngineKVFormat>(m, "EngineKVFormat")
+      .value("NB_NL_TWO_BS_NH_HS", EngineKVFormat::NB_NL_TWO_BS_NH_HS)
+      .value("NL_X_TWO_NB_BS_NH_HS", EngineKVFormat::NL_X_TWO_NB_BS_NH_HS)
+      .value("NL_X_NB_TWO_BS_NH_HS", EngineKVFormat::NL_X_NB_TWO_BS_NH_HS)
+      .value("NL_X_NB_BS_HS", EngineKVFormat::NL_X_NB_BS_HS)
+      .value("TWO_X_NL_X_NBBS_NH_HS", EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS)
+      .value("NL_X_NBBS_ONE_HS", EngineKVFormat::NL_X_NBBS_ONE_HS)
+      .value("NL_X_TWO_NB_NH_BS_HS", EngineKVFormat::NL_X_TWO_NB_NH_BS_HS)
+      .value("NL_X_NB_TWO_NH_BS_HS", EngineKVFormat::NL_X_NB_TWO_NH_BS_HS)
+      .value("NB_NL_TWO_NH_BS_HS", EngineKVFormat::NB_NL_TWO_NH_BS_HS)
+      .value("TWO_X_NL_X_NB_BS_NH_HS", EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS)
+      .value("NL_X_NB_NH_BS_TWO_HS", EngineKVFormat::NL_X_NB_NH_BS_TWO_HS)
+      .value("NL_X_NB_BS_NH_TWO_HS", EngineKVFormat::NL_X_NB_BS_NH_TWO_HS)
+      .export_values();
+
+  // Token-granular placement, every layer in one launch. Used by the packed
+  // load (H2D) and the coalesced packed store (D2H).
+  m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer,
+        py::arg("key_value"), py::arg("key_value_ptrs"),
+        py::arg("slot_mapping"), py::arg("paged_memory_device"),
+        py::arg("page_buffer_size"), py::arg("direction"),
+        py::arg("engine_kv_format"), py::arg("block_size") = 0,
+        py::arg("head_size") = 0, py::arg("skip_prefix_n_tokens") = 0,
+        py::call_guard<py::gil_scoped_release>());
+
+  // Token-granular placement for one layer. Used by the layer-overlap load,
+  // which needs a per-layer completion event and therefore cannot hand the
+  // whole slab to the multi-layer entry point. Reads the source pitch from the
+  // tensor's stride, so a non-contiguous single-layer slice of a packed slab
+  // is a valid argument.
+  m.def("single_layer_kv_transfer", &single_layer_kv_transfer,
+        py::arg("lmc_key_value_cache"), py::arg("vllm_key_value_cache"),
+        py::arg("slot_mapping"), py::arg("direction"),
+        py::arg("engine_kv_format"), py::arg("token_major") = false,
+        py::call_guard<py::gil_scoped_release>());
+
+  // Block-granular placement. Not called yet; bound so the per-block A/B can
+  // be wired without rebuilding the extension. Its payload pointers are
+  // dereferenced on the device, so the source must already be device-resident.
+  m.def("multi_layer_block_kv_transfer", &multi_layer_block_kv_transfer,
+        py::arg("paged_buffer_ptrs_tensor"), py::arg("lmcache_objects_ptrs"),
+        py::arg("block_ids"), py::arg("device"), py::arg("direction"),
+        py::arg("shape_desc"), py::arg("lmcache_chunk_size"),
+        py::arg("engine_kv_format"), py::arg("skip_prefix_n_blocks"),
+        py::call_guard<py::gil_scoped_release>());
+
+  py::class_<PageBufferShapeDesc>(m, "PageBufferShapeDesc")
+      .def(py::init<>())
+      .def_readwrite("kv_size", &PageBufferShapeDesc::kv_size)
+      .def_readwrite("nl", &PageBufferShapeDesc::nl)
+      .def_readwrite("nb", &PageBufferShapeDesc::nb)
+      .def_readwrite("bs", &PageBufferShapeDesc::bs)
+      .def_readwrite("nh", &PageBufferShapeDesc::nh)
+      .def_readwrite("hs", &PageBufferShapeDesc::hs)
+      .def_readwrite("element_size", &PageBufferShapeDesc::element_size)
+      .def_readwrite("block_stride_elems",
+                     &PageBufferShapeDesc::block_stride_elems);
+}

--- a/maru_vllm/connector.py
+++ b/maru_vllm/connector.py
@@ -89,10 +89,75 @@ _cuda_runtime: Any = None
 _cuda_memcpy2d_async: Any = None
 _cuda_memcpy2d_unavailable = False
 
+_kv_ops_module: Any = None
+_kv_ops_warned = False
+
+
+@dataclass(frozen=True)
+class _PitchedCopy:
+    """One ``cudaMemcpy2DAsync`` in a packed-layer gather.
+
+    Offsets are byte offsets, not addresses: the destination is relative to the
+    staging tensor and the source to run ``run_index``'s base, so the plan can
+    be built and checked before any pointer exists.
+    """
+
+    run_index: int
+    destination_offset: int
+    destination_pitch: int
+    source_offset: int
+    source_pitch: int
+    width_bytes: int
+    rows: int
+
 
 # ============================================================================
 # Utilities
 # ============================================================================
+
+
+def _resolve_kv_ops() -> Any | None:
+    """Return the paged-KV placement kernels, or None with one warning.
+
+    The kernels place a chunk's whole slab in one launch per chunk; without
+    them every load and store degrades to a copy per layer, which measured 148
+    vs 142.4 ms on a single-request cache hit and turned a chunk's single store
+    transfer into one per (chunk, layer). That gap is invisible in serving
+    metrics — it looks like a slower deployment, not an error — so the warning
+    names the build step that fixes it, and is emitted once per process rather
+    than once per load.
+
+    Returns:
+        The ``maru_kv_ops`` module when its extension is built, else None.
+    """
+    global _kv_ops_module, _kv_ops_warned
+    if _kv_ops_module is not None:
+        return _kv_ops_module
+    try:
+        import maru_kv_ops
+    except ImportError as error:  # pragma: no cover - package ships with maru
+        if not _kv_ops_warned:
+            _kv_ops_warned = True
+            logger.warning(
+                "Maru KV placement kernels unavailable (%s); every load and "
+                "store falls back to a copy per layer. Reinstall maru so "
+                "maru_kv_ops is importable.",
+                error,
+            )
+        return None
+    if not maru_kv_ops.is_available():
+        if not _kv_ops_warned:
+            _kv_ops_warned = True
+            logger.warning(
+                "Maru KV placement kernels were not built (%s); every load and "
+                "store falls back to a copy per layer, which is materially "
+                "slower. Reinstall maru on a host with the CUDA toolkit "
+                "(nvcc) and PyTorch to build them.",
+                maru_kv_ops.import_error(),
+            )
+        return None
+    _kv_ops_module = maru_kv_ops
+    return _kv_ops_module
 
 
 def _get_knob(extra_config: dict[str, Any], key: str, default: Any = False) -> Any:
@@ -1143,8 +1208,8 @@ class MaruWorkerConnector:
         # (possibly with no forward pass) and reuse it for layout dispatch.
         self._last_attn_metadata: Any = None
         # Resolved lazily by _packed_load_kernel_ctx / _packed_store_kernel_ctx
-        # for LMCache's multi_layer_kv_transfer kernel on the packed path.
-        self._lmc_ops: Any = None
+        # for the maru_kv_ops placement kernels on the packed path.
+        self._kv_ops: Any = None
 
         # P6: storage granularity. Default (off) packs all layers of a chunk
         # into one CXL object with one key — matching LMCache use_layerwise=
@@ -1847,6 +1912,11 @@ class MaruWorkerConnector:
         forward waits per layer instead of issuing anything itself. The
         transfer also gets a head start over the forward.
 
+        Each layer is staged through the copy engine and then placed by one
+        kernel launch, the same split the whole-request deferred path uses: the
+        media read rides the copy engine so it cannot hold SMs for its whole
+        duration, and only the address rearrangement runs on SMs.
+
         Args:
             req_meta: Metadata of the parked request.
             num_chunks: Chunks matched for this request.
@@ -1867,6 +1937,7 @@ class MaruWorkerConnector:
             pinned = self._pin_slot_mapping_for_async_h2d(slot_mapping)
             attn = self._last_attn_metadata
             tokens = num_chunks * self._kv_chunk_tokens
+            kernel = self._packed_store_kernel_ctx(attn)
             _t0 = time.monotonic()
             events: dict[str, torch.cuda.Event] = {}
             with torch.cuda.stream(stream):
@@ -1875,13 +1946,13 @@ class MaruWorkerConnector:
                     layer_dev = self._copy_packed_layer_to_device(
                         infos, num_chunks, true_idx, kv_cache_layer, stream
                     )
-                    self._inject_kv_into_layer(
+                    self._place_packed_layer(
                         kv_cache_layer,
                         layer_dev,
                         slot_gpu[:tokens],
                         attn,
                         layer_name,
-                        num_chunks=num_chunks,
+                        kernel,
                     )
                     event = torch.cuda.Event()
                     event.record(stream)
@@ -1923,10 +1994,13 @@ class MaruWorkerConnector:
 
         The background loader already completed Maru RPC/mmap lookup. This
         method runs at the beginning of the resumed forward: for layer k it
-        copies only that layer's K/V slices from every packed CXL slab, injects
+        copies only that layer's K/V slices from every packed CXL slab, places
         them into paged KV on ``_load_stream``, and records an event. Attention
         layer k waits for only that event, leaving layer k+1 transfer queued in
         parallel with layer k compute. No device-wide synchronize is used.
+
+        Placement takes the same kernel the loader-thread path uses, falling
+        back to a per-layer index-put where the kernel is unusable.
         """
         entries: list[tuple[MaruReqMeta, int, torch.Tensor, list[Any]]] = []
         missing: list[str] = []
@@ -1994,6 +2068,7 @@ class MaruWorkerConnector:
         # says nothing about those: they are loading correctly and their
         # forward must still wait on them.
         issued: dict[str, torch.cuda.Event] = {}
+        kernel = self._packed_store_kernel_ctx(attn_metadata)
         try:
             with torch.cuda.stream(load_stream):
                 slot_mappings_gpu = [
@@ -2011,13 +2086,13 @@ class MaruWorkerConnector:
                             kv_cache_layer,
                             load_stream,
                         )
-                        self._inject_kv_into_layer(
+                        self._place_packed_layer(
                             kv_cache_layer,
                             layer_dev,
                             slot_gpu[: num_chunks * self._kv_chunk_tokens],
                             attn_metadata,
                             layer_name,
-                            num_chunks=num_chunks,
+                            kernel,
                         )
                     event = torch.cuda.Event()
                     event.record(load_stream)
@@ -2072,9 +2147,16 @@ class MaruWorkerConnector:
         One packed page is ``[2, layers, tokens, hidden]``. For a contiguous
         page run, each layer's K (or V) plane is a fixed-width row separated
         by one page pitch. Two ``cudaMemcpy2DAsync`` calls gather every chunk
-        directly from registered CXL into ``[chunks, 2, tokens, hidden]``.
-        The caller can then inject all chunks with one kernel. Gapped page
-        allocations become multiple pitched runs but keep the same output.
+        directly from registered CXL. Gapped page allocations become multiple
+        pitched runs but keep the same output.
+
+        Returns:
+            ``[2, num_chunks * chunk_tokens, hidden]`` on the layer's device —
+            every chunk's K plane, then every chunk's V plane. Token order is
+            the request's, so index ``t`` of the middle axis is the token
+            ``slot_mapping[t]`` places. That is the shape
+            ``single_layer_kv_transfer`` reads with ``token_major=False``, and
+            the shape ``_inject_kv_into_layer`` reads with ``num_chunks=1``.
         """
         if not infos or num_chunks <= 0:
             raise ValueError("packed layer copy requires at least one chunk")
@@ -2087,44 +2169,138 @@ class MaruWorkerConnector:
         )
         hidden = first_slab.shape[-1]
         layer_dev = torch.empty(
-            (num_chunks, 2, self._kv_chunk_tokens, hidden),
+            (2, num_chunks * self._kv_chunk_tokens, hidden),
             dtype=kv_cache_layer.dtype,
             device=kv_cache_layer.device,
         )
-        plane_bytes = self._kv_chunk_tokens * hidden * kv_cache_layer.element_size()
-        slab_bytes = 2 * self._num_layers * plane_bytes
-        destination_pitch = 2 * plane_bytes
+        runs = self._chunk_runs(infos[:num_chunks])
+        # Held, not just their pointers: these alias the CXL mapping the copies
+        # read from, and the copies are still queued when this returns.
+        run_views = [
+            torch.frombuffer(run_view, dtype=kv_cache_layer.dtype)
+            for _, _, run_view in runs
+        ]
+        plan = self._packed_layer_copy_plan(
+            runs=[(start, count) for start, count, _ in runs],
+            num_chunks=num_chunks,
+            layer_idx=layer_idx,
+            plane_bytes=self._kv_chunk_tokens * hidden * kv_cache_layer.element_size(),
+        )
+        for copy in plan:
+            error = copy_2d(
+                layer_dev.data_ptr() + copy.destination_offset,
+                copy.destination_pitch,
+                run_views[copy.run_index].data_ptr() + copy.source_offset,
+                copy.source_pitch,
+                copy.width_bytes,
+                copy.rows,
+                1,  # cudaMemcpyHostToDevice
+                stream.cuda_stream,
+            )
+            if error != 0:
+                raise RuntimeError(f"cudaMemcpy2DAsync failed with code {error}")
+        return layer_dev
 
-        for chunk_start, run_chunks, run_view in self._chunk_runs(infos[:num_chunks]):
-            run_host = torch.frombuffer(run_view, dtype=kv_cache_layer.dtype)
+    def _packed_layer_copy_plan(
+        self,
+        runs: list[tuple[int, int]],
+        num_chunks: int,
+        layer_idx: int,
+        plane_bytes: int,
+    ) -> list[_PitchedCopy]:
+        """Lay out the pitched copies that gather one layer.
+
+        Split out from ``_copy_packed_layer_to_device`` because it is the part
+        that can be wrong without failing: a mis-derived offset copies the
+        neighbouring layer's bytes, and the load still reports success. Keeping
+        it free of tensors and CUDA lets a test replay it against a synthetic
+        slab and compare against the gather it is supposed to perform.
+
+        Args:
+            runs: ``(first chunk index, chunk count)`` per contiguous page run,
+                as ``_chunk_runs`` found them.
+            num_chunks: Chunks in the request, so the destination's K/V split.
+            layer_idx: Layer to gather, indexing the slab's layer axis.
+            plane_bytes: Bytes of one (chunk, layer, K or V) plane.
+
+        Returns:
+            Copies to issue, two per run (K then V). Offsets are relative to
+            the destination tensor and to each run's own base.
+        """
+        slab_bytes = 2 * self._num_layers * plane_bytes
+        half_bytes = num_chunks * plane_bytes
+        page_size = self._effective_page_size_bytes
+        plan: list[_PitchedCopy] = []
+        for run_index, (chunk_start, run_chunks) in enumerate(runs):
+            # Within a run, consecutive chunks sit one page apart. A single-chunk
+            # run has no second row, so its pitch only has to be >= the width.
             source_pitch = (
-                self._effective_page_size_bytes
-                if run_chunks > 1 and self._effective_page_size_bytes is not None
-                else slab_bytes
+                page_size if run_chunks > 1 and page_size is not None else slab_bytes
             )
             for kv_idx in range(2):
-                destination = (
-                    layer_dev.data_ptr()
-                    + chunk_start * destination_pitch
-                    + kv_idx * plane_bytes
+                plan.append(
+                    _PitchedCopy(
+                        run_index=run_index,
+                        # Chunks of one K/V half land back to back, so a run's
+                        # destination rows are adjacent: pitch is one plane.
+                        destination_offset=kv_idx * half_bytes
+                        + chunk_start * plane_bytes,
+                        destination_pitch=plane_bytes,
+                        source_offset=(kv_idx * self._num_layers + layer_idx)
+                        * plane_bytes,
+                        source_pitch=source_pitch,
+                        width_bytes=plane_bytes,
+                        rows=run_chunks,
+                    )
                 )
-                source = (
-                    run_host.data_ptr()
-                    + (kv_idx * self._num_layers + layer_idx) * plane_bytes
-                )
-                error = copy_2d(
-                    destination,
-                    destination_pitch,
-                    source,
-                    source_pitch,
-                    plane_bytes,
-                    run_chunks,
-                    1,  # cudaMemcpyHostToDevice
-                    stream.cuda_stream,
-                )
-                if error != 0:
-                    raise RuntimeError(f"cudaMemcpy2DAsync failed with code {error}")
-        return layer_dev
+        return plan
+
+    def _place_packed_layer(
+        self,
+        kv_cache_layer: torch.Tensor,
+        layer_dev: torch.Tensor,
+        slot_gpu: torch.Tensor,
+        attn_metadata: Any,
+        layer_name: str,
+        kernel: tuple | None,
+    ) -> None:
+        """Scatter one staged layer into the paged cache.
+
+        Both branches place the same bytes at the same addresses; they differ in
+        who computes those addresses. The kernel takes ``slot_gpu`` as it is and
+        derives each token's block and offset inline. The fallback has to
+        materialise those as two index tensors first, so it issues three kernels
+        per layer where the first issues one.
+
+        Args:
+            kv_cache_layer: The layer's paged KV tensor.
+            layer_dev: Device-resident ``[2, num_tokens, hidden]`` staging
+                tensor from ``_copy_packed_layer_to_device``.
+            slot_gpu: Device slot mapping covering exactly those tokens.
+            attn_metadata: Attention metadata for the fallback's layout dispatch.
+            layer_name: Layer being placed, for the fallback's dispatch.
+            kernel: Context from ``_packed_store_kernel_ctx``, or None to take
+                the fallback.
+        """
+        if kernel is None:
+            self._inject_kv_into_layer(
+                kv_cache_layer,
+                layer_dev,
+                slot_gpu,
+                attn_metadata,
+                layer_name,
+                num_chunks=1,
+            )
+            return
+        ops, _ptrs, _pbs, _block_size, _head_size, fmt = kernel
+        ops.single_layer_kv_transfer(
+            layer_dev,
+            kv_cache_layer,
+            slot_gpu,
+            ops.TransferDirection.H2D,
+            fmt,
+            token_major=False,
+        )
 
     def _fail_deferred_load(self, req_meta: MaruReqMeta) -> None:
         """Mark a deferred load as failed so the scheduler recomputes it.
@@ -2408,12 +2584,12 @@ class MaruWorkerConnector:
         """Load per-chunk slabs with no GPU staging (P6 v2, packed).
 
         The KV_2LTD slab (``[2, num_layers, chunk_tokens, hidden]``) is handed
-        whole to LMCache's ``multi_layer_kv_transfer``, which reads the pinned
+        whole to ``multi_layer_kv_transfer``, which reads the pinned
         CXL host memory directly (UVA) and scatters all layers into the paged
         GPU cache in one kernel per chunk — the same no-staging path LMCache's
         ``VLLMPagedMemGPUConnectorV2.to_gpu`` uses. This avoids both v1's 1,888
         tiny copies and the reverted GPU-staging OOM. Non-Flash layouts, CPU,
-        or a missing ``lmcache.c_ops`` fall back to a per-layer inject that
+        or an unbuilt ``maru_kv_ops`` fall back to a per-layer inject that
         reads the same slab slices.
 
         Deferred (between-step) requests are marked finished immediately (the
@@ -2520,8 +2696,8 @@ class MaruWorkerConnector:
 
         Returns ``(ops, kv_cache_pointers, page_buffer_size, block_size,
         head_size, engine_kv_format)`` when the fused no-staging kernel is
-        usable: Flash layout, CUDA, and ``lmcache.c_ops`` importable. This is
-        the DEFAULT packed load whenever available — it is not gated on any
+        usable: Flash layout, CUDA, and a built ``maru_kv_ops``. This is the
+        DEFAULT packed load whenever available — it is not gated on any
         configuration knob. The pointer table is indexed by each layer's true
         ``_get_layer_index`` so it aligns with the slab's layer dimension.
         Works with whatever paged axis order vLLM chose: dimensions and the
@@ -2548,18 +2724,12 @@ class MaruWorkerConnector:
         )
         if isinstance(layer_meta, (MLACommonMetadata, TritonAttentionMetadata)):
             return None
-        # Resolve lmcache.c_ops lazily.
-        if self._lmc_ops is None:
-            try:
-                import lmcache.c_ops as lmc_ops
-
-                self._lmc_ops = lmc_ops
-            except ImportError:
-                logger.warning(
-                    "Maru packed load: lmcache.c_ops unavailable; using "
-                    "per-layer inject fallback"
-                )
+        # Resolve the placement kernels lazily.
+        if self._kv_ops is None:
+            ops_module = _resolve_kv_ops()
+            if ops_module is None:
                 return None
+            self._kv_ops = ops_module
         # Dimensions and format come from one layout, so they cannot disagree.
         # The kernel takes raw pointers, so torch would not catch it if they did.
         block_size = layout.block_size
@@ -2569,8 +2739,8 @@ class MaruWorkerConnector:
         ptrs = torch.empty(len(layers), dtype=torch.int64, device="cpu")
         for _, kv_cache_layer, true_idx in layers:
             ptrs[true_idx] = kv_cache_layer.data_ptr()
-        ops = self._lmc_ops
-        # An older c_ops build may not carry every format; take the per-layer
+        ops = self._kv_ops
+        # A kernel build predating a format cannot place it; take the per-layer
         # fallback rather than raising out of the load path.
         kv_format = getattr(ops.EngineKVFormat, layout.format_name, None)
         if kv_format is None:
@@ -2858,7 +3028,7 @@ class MaruWorkerConnector:
           writes each chunk's slab with one ``multi_layer_kv_transfer(D2H)``
           — the store-side mirror of ``_load_packed``, collapsing
           ``(chunk x layer)`` GPU->CXL copies into one transfer per chunk.
-        - **Fallback** (non-Flash layout, CPU, or no ``lmcache.c_ops``): each
+        - **Fallback** (non-Flash layout, CPU, or unbuilt ``maru_kv_ops``): each
           layer's Flash extract ``[2, chunk_tokens, hidden]`` is written to
           ``slab[:, layer_idx]`` as before. Non-Flash extracts have a
           different rank and will raise (caught below → chunk skipped →
@@ -2986,13 +3156,16 @@ class MaruWorkerConnector:
                     logger.warning("Maru packed store failed: %s", base_key)
 
     def _packed_store_kernel_ctx(self, attn_metadata: Any) -> tuple | None:
-        """Kernel ctx for the coalesced packed store, or None for the fallback.
+        """Cached kernel ctx built from the registered caches, or None.
 
-        Same contract as ``_packed_load_kernel_ctx`` but built from the
-        registered KV caches (``save_kv_layer`` only sees one layer per call)
-        and cached — the pointer table is static after ``register_kv_caches``.
+        Named for the coalesced packed store, its first caller, but it now
+        serves every path that has no per-call layer list: the store (where
+        ``save_kv_layer`` sees one layer at a time) and the two asynchronous
+        loads (which run off the engine thread, after the forward that would
+        have supplied one). Same contract as ``_packed_load_kernel_ctx``, and
+        cached — the pointer table is static after ``register_kv_caches``.
         The kernel/fallback decision is stable across a step's per-layer calls
-        because every gate (device, tensor rank, layout, c_ops import) is
+        because every gate (device, tensor rank, layout, kernel import) is
         static, so the two paths never mix within one step. An unusable kernel
         is cached as ``False`` to avoid re-probing (e.g. re-attempting the
         import) on every per-layer call.

--- a/maru_vllm/connector.py
+++ b/maru_vllm/connector.py
@@ -2220,8 +2220,10 @@ class MaruWorkerConnector:
             device=kv_cache_layer.device,
         )
         runs = self._chunk_runs(infos[:num_chunks])
-        # Held, not just their pointers: these alias the CXL mapping the copies
-        # read from, and the copies are still queued when this returns.
+        # These alias the CXL mapping the copies read from. They only have to
+        # outlive the loop below, which is where the copies are queued; what
+        # keeps the mapping alive until the copies actually run is the caller
+        # retaining ``infos`` against the stream's completion event.
         run_views = [
             torch.frombuffer(run_view, dtype=kv_cache_layer.dtype)
             for _, _, run_view in runs
@@ -2317,6 +2319,15 @@ class MaruWorkerConnector:
         derives each token's block and offset inline. The fallback has to
         materialise those as two index tensors first, so it issues three kernels
         per layer where the first issues one.
+
+        That equivalence is the layout branch of ``_inject_kv_into_layer``,
+        with and without a K/V axis. Its MLA and legacy rank-4 Triton branches
+        reinterpret the staging buffer without consulting ``num_chunks``, so
+        they read a K/V-half-major slab as if it were token-major. Both derive
+        the same shapes from this staging tensor as from the chunk-major one it
+        replaced, and neither shape fits the paged tensor they assign to, so
+        those combinations raise out of the load and the request is recomputed
+        — the same outcome as before, not something this shape introduces.
 
         Args:
             kv_cache_layer: The layer's paged KV tensor.
@@ -3213,8 +3224,8 @@ class MaruWorkerConnector:
         The kernel/fallback decision is stable across a step's per-layer calls
         because every gate (device, tensor rank, layout, kernel import) is
         static, so the two paths never mix within one step. An unusable kernel
-        is cached as ``False`` to avoid re-probing (e.g. re-attempting the
-        import) on every per-layer call.
+        sets ``_store_kernel_unusable`` so it is not re-probed (e.g. the import
+        re-attempted) on every per-layer call.
         """
         if self._store_kernel_unusable:
             return None
@@ -3231,13 +3242,16 @@ class MaruWorkerConnector:
             self._store_kernel_unusable = True
         else:
             self._store_kernel_ctx = ctx
+        # Whichever path resolves this first gets to log it, and since the
+        # asynchronous loads now do, the message cannot name the store or a
+        # direction: the same context serves H2D placement and D2H stores.
         if ctx is not None:
             logger.info(
-                "Maru packed store: coalesced kernel D2H enabled (%d layers)",
+                "Maru packed transfers: coalesced kernel enabled (%d layers)",
                 self._num_layers,
             )
         else:
-            logger.info("Maru packed store: kernel unusable; per-layer fallback")
+            logger.info("Maru packed transfers: kernel unusable; per-layer fallback")
         return ctx
 
     def _store_packed_slabs(

--- a/maru_vllm/kv_layout.py
+++ b/maru_vllm/kv_layout.py
@@ -48,7 +48,7 @@ class KVLayout:
             layout describes exactly this shape and no other; ``_layout_fits``
             compares against it, so a hybrid model's differently-shaped layer
             can never be read through another layer's geometry.
-        format_name: ``lmcache.c_ops.EngineKVFormat`` member, or None when
+        format_name: ``maru_kv_ops.EngineKVFormat`` member, or None when
             this layout has no kernel form and must use per-layer transfers.
             Read only by the packed-kernel path, which walks memory itself.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,13 @@ Repository = "https://github.com/xcena-dev/maru"
 Documentation = "https://xcena-dev.github.io/maru/"
 Organization = "https://xcena.com"
 
+[tool.setuptools.package-data]
+# The vendored kernel sources are build inputs, so they have to travel with the
+# sdist; VENDOR.md travels with them because it is the provenance record.
+maru_kv_ops = ["csrc/*.cu", "csrc/*.cuh", "csrc/*.cpp", "csrc/*.h", "VENDOR.md"]
+
 [tool.setuptools.packages.find]
-include = ["maru*", "maru_server*", "maru_common*", "maru_shm*", "maru_vllm*", "maru_lmcache*", "maru_sglang*", "maru_tools*"]
+include = ["maru*", "maru_server*", "maru_common*", "maru_shm*", "maru_vllm*", "maru_lmcache*", "maru_sglang*", "maru_tools*", "maru_kv_ops*"]
 
 [tool.ruff]
 line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,43 @@
 """Setup script for Maru."""
 
 import os
-import shutil
 import sys
 from typing import Any
 
 from setuptools import Extension, setup
 
+_KV_OPS_NAME = "maru_kv_ops._C"
 _KV_OPS_SOURCES = [
     "maru_kv_ops/csrc/pybind.cpp",
     "maru_kv_ops/csrc/mem_kernels.cu",
     "maru_kv_ops/csrc/mp_mem_kernels.cu",
 ]
+_FALLBACK_NOTE = (
+    "The vLLM connector will use its per-layer fallback copy path, which is "
+    "materially slower. Rerun the install on a host with PyTorch and the CUDA "
+    "toolkit, without build isolation (install.sh does this for you)."
+)
+
+
+def _nvcc_path() -> str | None:
+    """Locate nvcc the way ``torch.utils.cpp_extension`` will.
+
+    PyTorch resolves the toolkit root once at import into ``CUDA_HOME`` and
+    then requires ``$CUDA_HOME/bin/nvcc`` to exist; a ``CUDA_HOME`` pointing
+    at a directory without nvcc makes its preflight raise rather than skip.
+    Asking PyTorch for the same root is what keeps this gate and that
+    preflight from disagreeing.
+
+    Returns:
+        Absolute path to nvcc, or None when PyTorch cannot find a toolkit.
+    """
+    from torch.utils import cpp_extension
+
+    cuda_home = cpp_extension.CUDA_HOME
+    if not cuda_home:
+        return None
+    nvcc = os.path.join(cuda_home, "bin", "nvcc.exe" if os.name == "nt" else "nvcc")
+    return nvcc if os.path.exists(nvcc) else None
 
 
 def _kv_ops_extension() -> Any | None:
@@ -38,19 +64,20 @@ def _kv_ops_extension() -> Any | None:
     except ImportError:
         print(
             "maru: PyTorch not importable; skipping the maru_kv_ops extension. "
-            "The vLLM connector will use its per-layer fallback copy path.",
+            "Note that a PEP 517 isolated build never sees PyTorch even when "
+            f"the target environment has it. {_FALLBACK_NOTE}",
             file=sys.stderr,
         )
         return None
-    if shutil.which("nvcc") is None and not os.environ.get("CUDA_HOME"):
+    if _nvcc_path() is None:
         print(
-            "maru: nvcc not found; skipping the maru_kv_ops extension. "
-            "The vLLM connector will use its per-layer fallback copy path.",
+            "maru: no CUDA toolkit (nvcc) found where PyTorch looks for it; "
+            f"skipping the maru_kv_ops extension. {_FALLBACK_NOTE}",
             file=sys.stderr,
         )
         return None
     return CUDAExtension(
-        name="maru_kv_ops._C",
+        name=_KV_OPS_NAME,
         sources=_KV_OPS_SOURCES,
         extra_compile_args={
             # The vendored translation units are compiled as-is; -O3 matches
@@ -63,6 +90,81 @@ def _kv_ops_extension() -> Any | None:
         # naming this build step before it falls back.
         optional=True,
     )
+
+
+def _optional_kv_ops_build(base: type) -> type:
+    """Wrap ``BuildExtension`` so a refused build drops only this extension.
+
+    ``optional=True`` covers a compile that fails once it has started:
+    setuptools catches per-extension compiler errors and moves on. PyTorch's
+    ``build_extensions`` opens with a CUDA and host-compiler preflight, which
+    sits *before* that loop, and every way it can disagree raises out of the
+    whole command instead — an nvcc major differing from the one PyTorch was
+    built against, or a host compiler outside the bounds the toolkit supports.
+    Maru's core still has to install on such a host, so the preflight is run
+    here first and a refusal drops the extension rather than the install.
+
+    Args:
+        base: PyTorch's ``BuildExtension`` command class.
+
+    Returns:
+        A subclass of it that treats the KV-ops extension as droppable.
+    """
+    from setuptools.command.build_ext import build_ext as _plain_build_ext
+
+    class _OptionalKVOpsBuild(base):  # type: ignore[misc, valid-type]
+        def build_extensions(self) -> None:
+            refusal = self._kv_ops_refusal()
+            if refusal is None:
+                super().build_extensions()
+                return
+            print(
+                f"maru: cannot build the maru_kv_ops extension ({refusal}). "
+                f"{_FALLBACK_NOTE}",
+                file=sys.stderr,
+            )
+            self.extensions = [
+                ext for ext in self._declared_extensions() if ext.name != _KV_OPS_NAME
+            ]
+            # Only plain C is left, so the base command builds it — and it
+            # does not re-run the preflight that just refused.
+            _plain_build_ext.build_extensions(self)
+
+        def _declared_extensions(self) -> list[Any]:
+            """Return the extensions this command was handed.
+
+            Wrapped because the base command class arrives as a runtime
+            argument, so mypy cannot resolve the attribute it declares.
+
+            Returns:
+                The current extension list.
+            """
+            return list(self.extensions)  # type: ignore[has-type]
+
+        def _kv_ops_refusal(self) -> Exception | None:
+            """Ask PyTorch's own checks whether this build can start.
+
+            Returns:
+                The exception the preflight raises, or None when it passes,
+                when the extension is not being built anyway, or when the
+                checks are not where this expects them (a PyTorch refactor
+                then leaves behaviour exactly as it is without them).
+            """
+            if not any(ext.name == _KV_OPS_NAME for ext in self._declared_extensions()):
+                return None
+            from torch.utils import cpp_extension
+
+            check_cuda_version = getattr(cpp_extension, "_check_cuda_version", None)
+            check_abi = getattr(self, "_check_abi", None)
+            if check_cuda_version is None or check_abi is None:
+                return None
+            try:
+                check_cuda_version(*check_abi())
+            except Exception as error:
+                return error
+            return None
+
+    return _OptionalKVOpsBuild
 
 
 def _build_config() -> dict[str, Any]:
@@ -91,7 +193,10 @@ def _build_config() -> dict[str, Any]:
     from torch.utils.cpp_extension import BuildExtension
 
     ext_modules.append(kv_ops)
-    return {"ext_modules": ext_modules, "cmdclass": {"build_ext": BuildExtension}}
+    return {
+        "ext_modules": ext_modules,
+        "cmdclass": {"build_ext": _optional_kv_ops_build(BuildExtension)},
+    }
 
 
 setup(**_build_config())

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,81 @@
 """Setup script for Maru."""
 
+import os
+import shutil
+import sys
+from typing import Any
+
 from setuptools import Extension, setup
 
-setup(
-    ext_modules=[
+_KV_OPS_SOURCES = [
+    "maru_kv_ops/csrc/pybind.cpp",
+    "maru_kv_ops/csrc/mem_kernels.cu",
+    "maru_kv_ops/csrc/mp_mem_kernels.cu",
+]
+
+
+def _kv_ops_extension() -> Any | None:
+    """Build the paged-KV placement extension, or None when tooling is absent.
+
+    Maru's core is import-free of PyTorch and installs on hosts with no GPU
+    toolchain, so this extension cannot be a hard build requirement. When
+    PyTorch or nvcc is missing the extension is skipped and the connectors take
+    their per-layer fallback; ``maru_kv_ops.is_available()`` reports which
+    happened at runtime.
+
+    ``optional=True`` on the extension is not enough on its own: importing
+    ``torch.utils.cpp_extension`` to *describe* the build already requires
+    PyTorch, so availability has to be settled before the object is created.
+
+    Returns:
+        A ``CUDAExtension`` when PyTorch and nvcc are both present, else None.
+    """
+    if os.environ.get("MARU_SKIP_KV_OPS"):
+        print("maru: MARU_SKIP_KV_OPS set; skipping maru_kv_ops extension")
+        return None
+    try:
+        from torch.utils.cpp_extension import CUDAExtension
+    except ImportError:
+        print(
+            "maru: PyTorch not importable; skipping the maru_kv_ops extension. "
+            "The vLLM connector will use its per-layer fallback copy path.",
+            file=sys.stderr,
+        )
+        return None
+    if shutil.which("nvcc") is None and not os.environ.get("CUDA_HOME"):
+        print(
+            "maru: nvcc not found; skipping the maru_kv_ops extension. "
+            "The vLLM connector will use its per-layer fallback copy path.",
+            file=sys.stderr,
+        )
+        return None
+    return CUDAExtension(
+        name="maru_kv_ops._C",
+        sources=_KV_OPS_SOURCES,
+        extra_compile_args={
+            # The vendored translation units are compiled as-is; -O3 matches
+            # how LMCache builds them.
+            "cxx": ["-O3"],
+            "nvcc": ["-O3"],
+        },
+        # A compile failure must not brick `pip install`. The runtime side is
+        # where an unbuilt extension is made loud: the connector logs a warning
+        # naming this build step before it falls back.
+        optional=True,
+    )
+
+
+def _build_config() -> dict[str, Any]:
+    """Assemble ext_modules and the matching build_ext command class.
+
+    ``CUDAExtension`` needs PyTorch's ``BuildExtension`` to compile; the plain
+    ``distutils`` build_ext does not know ``.cu``. The command class is
+    therefore only overridden when the extension is actually being built.
+
+    Returns:
+        Keyword arguments for ``setup()``.
+    """
+    ext_modules: list[Any] = [
         Extension(
             "maru_shm._cxl_flush",
             sources=["maru_shm/_cxl_flush.c"],
@@ -12,4 +84,14 @@ setup(
             optional=True,
         )
     ]
-)
+    kv_ops = _kv_ops_extension()
+    if kv_ops is None:
+        return {"ext_modules": ext_modules}
+
+    from torch.utils.cpp_extension import BuildExtension
+
+    ext_modules.append(kv_ops)
+    return {"ext_modules": ext_modules, "cmdclass": {"build_ext": BuildExtension}}
+
+
+setup(**_build_config())

--- a/tests/unit/test_kv_ops.py
+++ b/tests/unit/test_kv_ops.py
@@ -2,25 +2,33 @@
 # Copyright 2026 XCENA Inc.
 """Contract tests for the maru_kv_ops placement kernels.
 
-The kernel sources are vendored, so two things can drift without any test
-failing: the binding surface the connectors call, and the provenance record
-that the vendoring depends on. These tests pin both.
+The kernel sources are vendored, so three things can drift without any test
+failing: the binding surface the connectors call, the set of formats the
+kernels dispatch, and the provenance record that the vendoring depends on.
+These tests pin all three.
 
 No kernel is launched here — a launch needs a GPU and a real paged cache, and
 what these tests are for is catching drift on a vendor refresh. The C++ side of
-that drift is caught by the compiler, since ``pybind.cpp`` names every argument.
+the binding drift is caught by the compiler, since ``pybind.cpp`` names every
+argument.
+
+Everything except the binding surface reads files, so it runs on a host with
+neither PyTorch nor a CUDA toolkit — which is where CI runs, and therefore the
+only place these guards can fire before a review.
 """
 
+import hashlib
+import importlib.util
 import pathlib
+import re
 
 import pytest
 
-pytest.importorskip("torch", reason="torch not installed")
-
 import maru_kv_ops
 
-_CSRC = pathlib.Path(maru_kv_ops.__file__).parent / "csrc"
-_VENDOR_DOC = pathlib.Path(maru_kv_ops.__file__).parent / "VENDOR.md"
+_PACKAGE = pathlib.Path(maru_kv_ops.__file__).parent
+_CSRC = _PACKAGE / "csrc"
+_VENDOR_DOC = _PACKAGE / "VENDOR.md"
 
 # Emitted by maru_vllm.kv_layout for the rank-5 paged tensors vLLM's Flash
 # backends allocate. The kernels must be able to place all four.
@@ -44,6 +52,21 @@ requires_extension = pytest.mark.skipif(
     not maru_kv_ops.is_available(),
     reason=f"maru_kv_ops extension not built: {maru_kv_ops.import_error()}",
 )
+
+
+def _kv_layout_source() -> str:
+    """Read ``maru_vllm/kv_layout.py`` without importing it.
+
+    Importing ``maru_vllm`` pulls in PyTorch, which is exactly what these tests
+    avoid needing. ``find_spec`` on a top-level package resolves its location
+    without executing it.
+
+    Returns:
+        The module's source text.
+    """
+    spec = importlib.util.find_spec("maru_vllm")
+    assert spec is not None and spec.origin is not None, "maru_vllm not installed"
+    return (pathlib.Path(spec.origin).parent / "kv_layout.py").read_text()
 
 
 class TestPackagingContract:
@@ -84,7 +107,6 @@ class TestVendorProvenance:
         assert without == []
 
     def test_vendor_doc_pins_a_revision(self):
-        """A refresh that forgets to update the revision is a silent drift."""
         text = _VENDOR_DOC.read_text()
         assert "Apache-2.0" in text
         # A 40-character hex commit id, so "we copied from somewhere" cannot
@@ -94,6 +116,73 @@ class TestVendorProvenance:
             and all(c in "0123456789abcdef" for c in token.strip("`"))
             for token in text.split()
         )
+
+    def test_vendor_doc_records_every_copied_file(self):
+        recorded = self._recorded_digests()
+        assert sorted(recorded) == sorted(_VENDORED_SOURCES)
+
+    @pytest.mark.parametrize("name", _VENDORED_SOURCES)
+    def test_copied_file_matches_its_recorded_digest(self, name):
+        """New bytes under an old revision id is the drift that matters.
+
+        The revision line alone cannot catch it: a refresh that copies the
+        files and forgets the table leaves a record that reads as authoritative
+        and is wrong. Comparing the bytes is what makes the record a claim the
+        suite checks rather than a comment.
+        """
+        recorded = self._recorded_digests()
+        actual = hashlib.sha256((_CSRC / name).read_bytes()).hexdigest()
+        assert actual == recorded[name], (
+            f"{name} does not match the digest in VENDOR.md. Refresh the table "
+            "(and the revision above it) with: cd maru_kv_ops/csrc && "
+            "sha256sum *.h *.cu *.cuh"
+        )
+
+    @staticmethod
+    def _recorded_digests() -> dict[str, str]:
+        """Parse the SHA-256 table out of VENDOR.md.
+
+        Returns:
+            Vendored file base name -> the digest recorded for it.
+        """
+        pattern = re.compile(r"`csrc/([\w.]+)`\s*\|\s*`([0-9a-f]{64})`")
+        return dict(pattern.findall(_VENDOR_DOC.read_text()))
+
+
+class TestFormatDispatch:
+    """Every format the connector can hand a kernel has to reach a case.
+
+    The connector's gate accepts any format the ``EngineKVFormat`` enum names,
+    because it was written for ``multi_layer_kv_transfer``. The layer-overlap
+    load calls ``single_layer_kv_transfer``, whose switch covers a narrower
+    set and raises on the rest. The two agree today; a vendor refresh or a new
+    paged layout is where they would stop agreeing, and the failure lands
+    inside a CUDA stream at serving time rather than here.
+    """
+
+    @staticmethod
+    def _single_layer_cases() -> set[str]:
+        """Formats ``single_layer_kv_transfer`` dispatches, read from its switch."""
+        source = (_CSRC / "mem_kernels.cu").read_text()
+        cases = re.findall(
+            r"LAUNCH_SINGLE_LAYER_KERNEL\(EngineKVFormat::(\w+)\)", source
+        )
+        assert cases, "the single-layer switch moved; this test needs updating"
+        return set(cases)
+
+    @pytest.mark.parametrize("fmt", _FORMATS_MARU_EMITS)
+    def test_single_layer_transfer_dispatches_the_format(self, fmt):
+        assert fmt in self._single_layer_cases()
+
+    def test_the_recorded_format_list_is_what_kv_layout_emits(self):
+        """Keeps the list above honest when a layout is added or renamed.
+
+        Format names are the only screaming-case string literals in
+        ``kv_layout.py``, so reading them out of the source keeps this list
+        tied to the module without importing it.
+        """
+        emitted = set(re.findall(r'"([A-Z][A-Z0-9_]{5,})"', _kv_layout_source()))
+        assert emitted == set(_FORMATS_MARU_EMITS)
 
 
 @requires_extension

--- a/tests/unit/test_kv_ops.py
+++ b/tests/unit/test_kv_ops.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 XCENA Inc.
+"""Contract tests for the maru_kv_ops placement kernels.
+
+The kernel sources are vendored, so two things can drift without any test
+failing: the binding surface the connectors call, and the provenance record
+that the vendoring depends on. These tests pin both.
+
+No kernel is launched here — a launch needs a GPU and a real paged cache, and
+what these tests are for is catching drift on a vendor refresh. The C++ side of
+that drift is caught by the compiler, since ``pybind.cpp`` names every argument.
+"""
+
+import pathlib
+
+import pytest
+
+pytest.importorskip("torch", reason="torch not installed")
+
+import maru_kv_ops
+
+_CSRC = pathlib.Path(maru_kv_ops.__file__).parent / "csrc"
+_VENDOR_DOC = pathlib.Path(maru_kv_ops.__file__).parent / "VENDOR.md"
+
+# Emitted by maru_vllm.kv_layout for the rank-5 paged tensors vLLM's Flash
+# backends allocate. The kernels must be able to place all four.
+_FORMATS_MARU_EMITS = (
+    "NL_X_NB_TWO_BS_NH_HS",
+    "NL_X_NB_TWO_NH_BS_HS",
+    "NL_X_TWO_NB_BS_NH_HS",
+    "NL_X_TWO_NB_NH_BS_HS",
+)
+
+_VENDORED_SOURCES = (
+    "engine_kv_format.h",
+    "kv_transfer_types.h",
+    "mem_kernels.cu",
+    "mem_kernels.cuh",
+    "mp_mem_kernels.cu",
+    "mp_mem_kernels.cuh",
+)
+
+requires_extension = pytest.mark.skipif(
+    not maru_kv_ops.is_available(),
+    reason=f"maru_kv_ops extension not built: {maru_kv_ops.import_error()}",
+)
+
+
+class TestPackagingContract:
+    """Holds whether or not the extension was built."""
+
+    def test_import_never_raises(self):
+        """maru_vllm imports this package at load time on every host."""
+        assert isinstance(maru_kv_ops.is_available(), bool)
+
+    def test_unavailable_attribute_names_the_build_step(self):
+        if maru_kv_ops.is_available():
+            pytest.skip("extension is built; the guidance path is unreachable")
+        with pytest.raises(AttributeError, match="nvcc"):
+            _ = maru_kv_ops.multi_layer_kv_transfer
+
+    def test_unknown_attribute_still_reports_the_module(self):
+        with pytest.raises(AttributeError, match="has no attribute"):
+            _ = maru_kv_ops.no_such_symbol
+
+    def test_import_error_agrees_with_availability(self):
+        assert (maru_kv_ops.import_error() is None) == maru_kv_ops.is_available()
+
+
+class TestVendorProvenance:
+    """Apache-2.0 obligations and the refresh record are part of the package."""
+
+    def test_every_vendored_source_is_present(self):
+        missing = [name for name in _VENDORED_SOURCES if not (_CSRC / name).is_file()]
+        assert missing == []
+
+    def test_vendored_sources_keep_their_spdx_header(self):
+        without = [
+            name
+            for name in _VENDORED_SOURCES
+            if "SPDX-License-Identifier: Apache-2.0"
+            not in (_CSRC / name).read_text().splitlines()[0]
+        ]
+        assert without == []
+
+    def test_vendor_doc_pins_a_revision(self):
+        """A refresh that forgets to update the revision is a silent drift."""
+        text = _VENDOR_DOC.read_text()
+        assert "Apache-2.0" in text
+        # A 40-character hex commit id, so "we copied from somewhere" cannot
+        # pass as provenance.
+        assert any(
+            len(token.strip("`")) == 40
+            and all(c in "0123456789abcdef" for c in token.strip("`"))
+            for token in text.split()
+        )
+
+
+@requires_extension
+class TestBindingSurface:
+    """What the connectors call has to exist, with the names they pass."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "multi_layer_kv_transfer",
+            "single_layer_kv_transfer",
+            "multi_layer_block_kv_transfer",
+        ],
+    )
+    def test_entry_point_is_bound(self, name):
+        assert callable(getattr(maru_kv_ops, name))
+
+    @pytest.mark.parametrize("fmt", _FORMATS_MARU_EMITS)
+    def test_format_maru_emits_is_bound(self, fmt):
+        assert hasattr(maru_kv_ops.EngineKVFormat, fmt)
+
+    def test_both_directions_are_bound(self):
+        assert maru_kv_ops.TransferDirection.H2D is not None
+        assert maru_kv_ops.TransferDirection.D2H is not None
+
+    def test_single_layer_accepts_token_major(self):
+        """The layer-overlap path passes token_major to select [2, T, H]."""
+        assert "token_major" in maru_kv_ops.single_layer_kv_transfer.__doc__
+
+    def test_multi_layer_accepts_the_dimension_keywords(self):
+        doc = maru_kv_ops.multi_layer_kv_transfer.__doc__
+        for keyword in ("block_size", "head_size", "skip_prefix_n_tokens"):
+            assert keyword in doc
+
+    def test_shape_desc_exposes_every_field(self):
+        desc = maru_kv_ops.PageBufferShapeDesc()
+        for field in (
+            "kv_size",
+            "nl",
+            "nb",
+            "bs",
+            "nh",
+            "hs",
+            "element_size",
+            "block_stride_elems",
+        ):
+            setattr(desc, field, 1)
+            assert getattr(desc, field) == 1

--- a/tests/unit/test_vllm_connector.py
+++ b/tests/unit/test_vllm_connector.py
@@ -2633,7 +2633,7 @@ class TestPackedStorage:
         assert sched_lw._chunk_exists_key("kv_abc") == "kv_abc_DONE"
 
     def _fake_store_kernel(self, kv_layers):
-        """Fake multi_layer_kv_transfer ctx mirroring the c_ops D2H branch.
+        """Fake multi_layer_kv_transfer ctx mirroring the kernel D2H branch.
 
         For engine_kv_format NL_X_TWO_NB_BS_NH_HS the D2H direction gathers
         ``paged[:, slots]`` of every layer into the KV_2LTD slab
@@ -2996,8 +2996,8 @@ class TestPackedStorage:
         i.e. for engine_kv_format NL_X_TWO_NB_BS_NH_HS the slab must be
         [2, num_layers, tokens, hidden] and each layer's paged buffer
         [2, page_buffer_size, hidden]. If our _save_kv_layer_packed layout ever
-        diverges from this, the (bit-exact) assertion breaks. The real c_ops
-        kernel is validated end-to-end by the device benchmark.
+        diverges from this, the (bit-exact) assertion breaks. The real
+        maru_kv_ops kernel is validated end-to-end by the device benchmark.
         """
         num_layers, ct, hidden = 3, self.CHUNK, 2
         page_buffer_size = 32

--- a/tests/unit/test_vllm_connector.py
+++ b/tests/unit/test_vllm_connector.py
@@ -3175,3 +3175,258 @@ class TestActiveLoadRefsRelease:
         worker._release_completed_load_refs()
 
         assert worker._active_load_refs == []
+
+
+class TestKvOpsResolution:
+    """The placement kernels are resolved once, and their absence is loud.
+
+    An unbuilt extension costs measured throughput but raises nothing, so the
+    warning is the only signal a deployment gets. These tests pin that it is
+    emitted, that it names the fix, and that it does not repeat per load.
+    """
+
+    @staticmethod
+    def _reset() -> None:
+        import maru_vllm.connector as conn
+
+        conn._kv_ops_module = None
+        conn._kv_ops_warned = False
+
+    def teardown_method(self) -> None:
+        self._reset()
+
+    def test_returns_module_when_extension_built(self, monkeypatch):
+        import maru_vllm.connector as conn
+
+        self._reset()
+        stub = SimpleNamespace(is_available=lambda: True, import_error=lambda: None)
+        monkeypatch.setitem(__import__("sys").modules, "maru_kv_ops", stub)
+
+        assert conn._resolve_kv_ops() is stub
+
+    def test_caches_the_resolved_module(self, monkeypatch):
+        import maru_vllm.connector as conn
+
+        self._reset()
+        calls = []
+
+        class Stub:
+            @staticmethod
+            def is_available():
+                calls.append(1)
+                return True
+
+            @staticmethod
+            def import_error():
+                return None
+
+        monkeypatch.setitem(__import__("sys").modules, "maru_kv_ops", Stub)
+
+        assert conn._resolve_kv_ops() is Stub
+        assert conn._resolve_kv_ops() is Stub
+        assert len(calls) == 1
+
+    def test_unbuilt_extension_warns_once_and_names_the_fix(self, monkeypatch, caplog):
+        import maru_vllm.connector as conn
+
+        self._reset()
+        stub = SimpleNamespace(
+            is_available=lambda: False,
+            import_error=lambda: ImportError("no _C"),
+        )
+        monkeypatch.setitem(__import__("sys").modules, "maru_kv_ops", stub)
+
+        with caplog.at_level("WARNING"):
+            assert conn._resolve_kv_ops() is None
+            assert conn._resolve_kv_ops() is None
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "nvcc" in message
+        assert "Reinstall maru" in message
+
+    def test_kernel_ctx_takes_the_fallback_when_unbuilt(self, monkeypatch):
+        """An unbuilt extension must reach the per-layer path, not raise."""
+        self._reset()
+        stub = SimpleNamespace(
+            is_available=lambda: False, import_error=lambda: ImportError("no _C")
+        )
+        monkeypatch.setitem(__import__("sys").modules, "maru_kv_ops", stub)
+        worker = make_bare_worker()
+        worker._kv_ops = None
+        worker._kv_layout = SimpleNamespace(format_name="NL_X_NB_TWO_BS_NH_HS")
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+        layer = torch.zeros(2, 2, 4, 1)
+        monkeypatch.setattr(
+            type(layer), "device", property(lambda _self: torch.device("cuda"))
+        )
+
+        assert (
+            worker._packed_load_kernel_ctx(
+                [("l0", layer, 0)], make_flash_attn_metadata()
+            )
+            is None
+        )
+
+
+class TestPackedLayerCopyPlan:
+    """The gather plan must select the requested layer, in request token order.
+
+    A wrong offset here copies a neighbouring layer's bytes and the load still
+    reports success, so the plan is replayed against a synthetic packed slab
+    and compared with the gather it stands for. Byte arithmetic only — no CUDA.
+    """
+
+    @staticmethod
+    def _worker(num_layers: int, chunk_tokens: int, page_size: int | None):
+        worker = make_bare_worker()
+        worker._num_layers = num_layers
+        worker._kv_chunk_tokens = chunk_tokens
+        worker._effective_page_size_bytes = page_size
+        return worker
+
+    @staticmethod
+    def _slab(num_chunks: int, num_layers: int, chunk_tokens: int, hidden: int):
+        """A packed slab whose every element encodes where it came from."""
+        return torch.arange(
+            num_chunks * 2 * num_layers * chunk_tokens * hidden, dtype=torch.int32
+        ).view(num_chunks, 2, num_layers, chunk_tokens, hidden)
+
+    def _replay(self, plan, slab, run_offsets, destination_numel, itemsize):
+        """Execute a plan over flat byte buffers, as cudaMemcpy2DAsync would."""
+        source = slab.reshape(-1).contiguous().numpy().tobytes()
+        destination = bytearray(destination_numel * itemsize)
+        for copy in plan:
+            base = run_offsets[copy.run_index]
+            for row in range(copy.rows):
+                src = base + copy.source_offset + row * copy.source_pitch
+                dst = copy.destination_offset + row * copy.destination_pitch
+                destination[dst : dst + copy.width_bytes] = source[
+                    src : src + copy.width_bytes
+                ]
+        return torch.frombuffer(bytes(destination), dtype=torch.int32)
+
+    @pytest.mark.parametrize("layer_idx", [0, 1, 2])
+    def test_contiguous_run_gathers_the_requested_layer(self, layer_idx):
+        num_chunks, num_layers, chunk_tokens, hidden = 3, 3, 4, 2
+        itemsize = 4
+        plane_bytes = chunk_tokens * hidden * itemsize
+        slab_bytes = 2 * num_layers * plane_bytes
+        worker = self._worker(num_layers, chunk_tokens, slab_bytes)
+        slab = self._slab(num_chunks, num_layers, chunk_tokens, hidden)
+
+        plan = worker._packed_layer_copy_plan(
+            runs=[(0, num_chunks)],
+            num_chunks=num_chunks,
+            layer_idx=layer_idx,
+            plane_bytes=plane_bytes,
+        )
+        got = self._replay(
+            plan, slab, [0], 2 * num_chunks * chunk_tokens * hidden, itemsize
+        )
+
+        # [2, num_chunks * chunk_tokens, hidden]: K for every chunk, then V.
+        expected = slab[:, :, layer_idx].permute(1, 0, 2, 3).reshape(-1).contiguous()
+        assert torch.equal(got, expected)
+
+    def test_gapped_runs_produce_the_same_gather(self):
+        """Two runs must land in the same order as one covering both chunks."""
+        num_chunks, num_layers, chunk_tokens, hidden = 2, 4, 2, 3
+        itemsize = 4
+        plane_bytes = chunk_tokens * hidden * itemsize
+        slab_bytes = 2 * num_layers * plane_bytes
+        worker = self._worker(num_layers, chunk_tokens, slab_bytes)
+        slab = self._slab(num_chunks, num_layers, chunk_tokens, hidden)
+
+        # One run per chunk, each starting at its own slab base.
+        plan = worker._packed_layer_copy_plan(
+            runs=[(0, 1), (1, 1)],
+            num_chunks=num_chunks,
+            layer_idx=2,
+            plane_bytes=plane_bytes,
+        )
+        got = self._replay(
+            plan,
+            slab,
+            [0, slab_bytes],
+            2 * num_chunks * chunk_tokens * hidden,
+            itemsize,
+        )
+
+        expected = slab[:, :, 2].permute(1, 0, 2, 3).reshape(-1).contiguous()
+        assert torch.equal(got, expected)
+
+    def test_single_chunk_run_pitch_covers_the_width(self):
+        """A one-row copy still needs pitch >= width or cudaMemcpy2D errors."""
+        worker = self._worker(num_layers=2, chunk_tokens=4, page_size=None)
+
+        plan = worker._packed_layer_copy_plan(
+            runs=[(0, 1)], num_chunks=1, layer_idx=0, plane_bytes=32
+        )
+
+        assert all(c.source_pitch >= c.width_bytes for c in plan)
+        assert all(c.destination_pitch >= c.width_bytes for c in plan)
+
+    def test_plan_is_two_copies_per_run(self):
+        worker = self._worker(num_layers=2, chunk_tokens=4, page_size=64)
+
+        plan = worker._packed_layer_copy_plan(
+            runs=[(0, 2), (2, 1)], num_chunks=3, layer_idx=1, plane_bytes=32
+        )
+
+        assert len(plan) == 4
+        assert [c.run_index for c in plan] == [0, 0, 1, 1]
+        assert [c.rows for c in plan] == [2, 2, 1, 1]
+
+
+class TestPlacePackedLayer:
+    """Both placement branches must write the same bytes to the same slots."""
+
+    def test_kernel_branch_calls_the_single_layer_entry_point(self):
+        worker = make_bare_worker()
+        recorded = {}
+
+        class Ops:
+            TransferDirection = SimpleNamespace(H2D="h2d")
+
+            @staticmethod
+            def single_layer_kv_transfer(*args, **kwargs):
+                recorded["args"] = args
+                recorded["kwargs"] = kwargs
+
+        layer = torch.zeros(2, 2, 4, 1)
+        staged = torch.zeros(2, 8, 1)
+        slots = torch.arange(8)
+        kernel = (Ops, "ptrs", 16, 2, 1, "fmt")
+
+        worker._place_packed_layer(layer, staged, slots, None, "l0", kernel)
+
+        assert recorded["args"][0] is staged
+        assert recorded["args"][1] is layer
+        assert recorded["args"][2] is slots
+        assert recorded["args"][3] == "h2d"
+        assert recorded["args"][4] == "fmt"
+        # token_major=False is the [2, num_tokens, hidden] contract the staging
+        # tensor is built to; True would transpose K and V.
+        assert recorded["kwargs"] == {"token_major": False}
+
+    def test_fallback_branch_injects_as_one_run(self, monkeypatch):
+        worker = make_bare_worker()
+        recorded = {}
+
+        def fake_inject(*args, **kwargs):
+            recorded["args"] = args
+            recorded["kwargs"] = kwargs
+
+        monkeypatch.setattr(worker, "_inject_kv_into_layer", fake_inject)
+        layer = torch.zeros(2, 2, 4, 1)
+        staged = torch.zeros(2, 8, 1)
+        slots = torch.arange(8)
+
+        worker._place_packed_layer(layer, staged, slots, "attn", "l0", None)
+
+        # num_chunks=1 is what makes _inject_kv_into_layer read the staging
+        # tensor as [2, num_tokens, hidden] rather than chunk-major.
+        assert recorded["kwargs"] == {"num_chunks": 1}
+        assert recorded["args"][1] is staged

--- a/tests/unit/test_vllm_connector.py
+++ b/tests/unit/test_vllm_connector.py
@@ -3399,6 +3399,43 @@ class TestPackedLayerCopyPlan:
         expected = slab[:, :, 2].permute(1, 0, 2, 3).reshape(-1).contiguous()
         assert torch.equal(got, expected)
 
+    def test_gapped_multi_chunk_runs_stay_contiguous_per_half(self):
+        """Chunked prefill's real shape: two runs, several chunks each.
+
+        This is where the destination arithmetic can go wrong without any
+        symptom. A run's rows are one page apart at the source but adjacent at
+        the destination, and the second run has to resume inside the K half
+        where the first left off — not at the half's start, and not past the
+        boundary into V.
+        """
+        num_chunks, num_layers, chunk_tokens, hidden = 4, 3, 2, 2
+        itemsize = 4
+        plane_bytes = chunk_tokens * hidden * itemsize
+        slab_bytes = 2 * num_layers * plane_bytes
+        worker = self._worker(num_layers, chunk_tokens, slab_bytes)
+        # Five slots hold the four chunks: the second run starts at slot 3, so
+        # slot 2 is the gap a fresh allocation burst leaves behind.
+        occupied = [0, 1, 3, 4]
+        slab = self._slab(len(occupied) + 1, num_layers, chunk_tokens, hidden)
+
+        plan = worker._packed_layer_copy_plan(
+            runs=[(0, 2), (2, 2)],
+            num_chunks=num_chunks,
+            layer_idx=1,
+            plane_bytes=plane_bytes,
+        )
+        got = self._replay(
+            plan,
+            slab,
+            [0, 3 * slab_bytes],
+            2 * num_chunks * chunk_tokens * hidden,
+            itemsize,
+        )
+
+        expected = slab[occupied][:, :, 1].permute(1, 0, 2, 3).reshape(-1).contiguous()
+        assert torch.equal(got, expected)
+        assert [c.rows for c in plan] == [2, 2, 2, 2]
+
     def test_single_chunk_run_pitch_covers_the_width(self):
         """A one-row copy still needs pitch >= width or cudaMemcpy2D errors."""
         worker = self._worker(num_layers=2, chunk_tokens=4, page_size=None)


### PR DESCRIPTION
## 🤔 Background & Motivation (Why)

vLLM 직결 커넥터는 LMCache 를 거치지 않고 Maru 에 닿는 것이 존재 이유인데, **KV 복사의 기본 경로가 `lmcache.c_ops` 를 부르고 있었습니다.** 그 요구사항은 선언된 적도 없습니다. `pyproject.toml` 의 의존성은 `pyzmq`·`msgpack`·`dacite` 셋뿐입니다.

이 의존은 두 가지 방식으로 배포를 해칩니다.

**첫째, 없으면 조용히 느려집니다.** 오류가 아니라 경고 한 줄을 남기고 레이어별 복사 경로로 내려갑니다. 그 경로의 비용은 커널 채택 당시 실측돼 있습니다. 로드는 동시 1 건 캐시 히트 첫 토큰 148 대 142.4 ms, 저장은 청크당 전송 1 회가 (청크 × 레이어) 당 1 회로 늘어납니다. 배포 입장에서 이것은 오류로 보이지 않고 **그냥 느린 장비로 보입니다.**

**둘째, 기본 경로가 다른 프로젝트의 내부 구조에 매여 있습니다.** 커넥터는 `ops.EngineKVFormat` 과 `ops.TransferDirection` 처럼 외부 확장의 내부 이름을 다섯 곳에서 직접 읽습니다. 그 이름의 위치와 형태는 Maru 가 정하지도 고정하지도 못하고, 의존이 선언돼 있지 않으니 어느 세대가 설치될지도 알 수 없습니다. `getattr(ops.EngineKVFormat, layout.format_name, None)` 의 기본값 가드는 형식 이름 하나가 없는 경우만 받아 주고, enum 자체가 그 자리에 없는 경우는 받지 못합니다. 그래서 상류가 내부 배치를 정리하면 그 변화가 **커넥터의 기본 KV 복사 경로에서, 그것도 모델 forward 안에서 처음 드러납니다.**

이 PR 은 그 묶임을 끊습니다. 병합 후 `maru_vllm/` 안에 `lmcache` 참조가 한 건도 남지 않습니다.

부수적으로 하나 더 있습니다. 레이어 겹침 경로만 KV 배치를 PyTorch 범용 인덱싱으로 하고 있어서, 겹침을 끈 팔(커널 사용)과 켠 팔(PyTorch 사용)의 비교에 **배치 구현 차이가 교란으로 섞여 있었습니다.**

## 🏗️ Design Changes

### LMCache 의존의 제거

KV 배치 커널을 Maru 안으로 들여옵니다. 커넥터가 의존하는 상대가 외부 패키지에서 Maru 자신의 빌드 산출물로 바뀝니다. 남는 관계는 소스 출처뿐이고, import 도 버전 추적도 없습니다.

**Before** — 선언되지 않은 외부 의존이 기본 경로에 있습니다. 패키지가 없으면 조용히 느려지고, 있어도 그 내부 이름이 바뀌면 기본 경로가 흔들립니다.

```mermaid
flowchart LR
    C1["MaruKVConnector"] ==>|"import lmcache.c_ops<br/>pyproject 미선언"| K1["LMCache 확장"]
    K1 ==> G1["paged KV cache"]
    C1 -.->|"패키지 없으면<br/>경고 한 줄"| F1["레이어별 복사 폴백"]
    F1 --> G1
    K1 --> X1["내부 이름이 바뀌면<br/>forward 안에서 처음 드러남"]
```

**After** — 의존이 사라지고, 커널이 없을 때는 빌드 단계를 지목한 경고가 나갑니다.

```mermaid
flowchart LR
    C2["MaruKVConnector"] ==> O2["maru_kv_ops<br/>Maru 빌드 산출물"]
    C2 -.->|"안 빌드됐으면<br/>빌드 단계를 지목한 경고"| F2["레이어별 복사 폴백"]
    O2 ==> G2["paged KV cache"]
    F2 --> G2
```

커널 소스는 LMCache 에서 **바이트 단위로 그대로** 가져옵니다(Apache-2.0). 손대지 않는 이유는 갱신을 「파일 복사 + diff」로 유지하기 위해서입니다. 안 쓰는 진입점 다섯 개가 함께 컴파일되지만, 그것을 지우면 「특정 상류 리비전과 동일」이라는 성질이 깨집니다. 바인딩 층은 Maru 자신의 것이고 커넥터가 부르는 진입점만 노출하므로, **상류 서명이 바뀌면 컴파일 오류로 드러납니다.** 런타임에 죽는 대신 빌드에서 걸린다는 것이 이 PR 이 바꾸는 핵심입니다.

가져온 리비전은 **의도적으로 상류 최신이 아닙니다.** 지금까지 성능 측정에 쓰인 LMCache 빌드가 컴파일된 리비전을 고정했습니다. 그래야 이 PR 이 「포장을 바꿨을 뿐」임을 비교로 확인할 수 있습니다. 상류는 그 뒤 배치 형식 두 개를 추가하고 형식 정의를 리팩터해 API 표면을 바꿨는데, 그 채택은 별도 실기 비교가 필요한 작업입니다.

### 커널은 선택 사항이고, 설치는 그것을 만들어야 한다

Maru 코어는 PyTorch 도 GPU 툴체인도 없는 호스트에 설치되어야 합니다. 그래서 확장은 **PyTorch 와 nvcc 가 모두 있을 때만** 빌드되고, 없으면 건너뜁니다.

그런데 「선택 사항」이 「기본적으로 안 만들어짐」이 되면 안 됩니다. `pip install -e .` 과 `uv pip install -e .` 은 PEP 517 빌드 격리를 기본으로 쓰고, 격리된 환경에는 `[build-system].requires` 의 setuptools·wheel 만 있습니다. `setup.py` 는 확장을 `torch.utils.cpp_extension` 으로 기술하므로, 대상 환경에 PyTorch 가 있어도 **빌드를 기술하는 import 자체가 실패해 확장이 생략됩니다.** 그리고 그 안내 메시지는 pip 이 삼키는 빌드 서브프로세스 stderr 로 나가서 설치 시점에는 보이지도 않습니다.

그래서 설치 경로가 판단을 대신합니다. `install.sh` 가 설치 대상 환경에 PyTorch 가 있는지 보고, 있으면 빌드 백엔드를 먼저 넣고 `--no-build-isolation` 으로 설치한 뒤 **커널이 실제로 호출 가능한지 보고합니다.** 없으면 격리를 유지하고 어떤 경로로 돌게 되는지 알립니다. 설치 안내 문서에도 같은 내용을 넣었습니다.

빌드가 실패해도 설치는 깨지지 않아야 합니다. 그런데 `optional=True` 로는 부족합니다. setuptools 는 확장별 컴파일 오류를 흡수하지만, PyTorch 의 `build_extensions` 는 그 루프 **앞에서** CUDA·호스트 컴파일러 전처리 검사를 돌리고, 거기서 나오는 예외는 명령 전체를 타고 올라갑니다. nvcc major 가 PyTorch 가 빌드된 CUDA 와 다르면 `pip install` 이 그대로 죽습니다. 그 전처리 검사를 미리 돌려서, 거부하면 확장만 목록에서 빼고 설치를 계속합니다.

### 레이어 겹침의 KV 배치

겹침 경로만 남아 있던 PyTorch 범용 인덱싱을 커널로 바꿉니다. 두 방식은 같은 바이트를 같은 주소에 놓지만, **그 주소를 누가 계산하는지**가 다릅니다.

**Before** — 목적지 주소를 GPU 텐서 두 개로 먼저 만든 뒤 범용 연산에 넘깁니다.

```mermaid
flowchart LR
    B1["GPU 스테이징 버퍼"] --> B2["블록 번호 텐서"]
    B1 --> B3["칸 번호 텐서"]
    B2 --> B4["PyTorch 범용 배치"]
    B3 --> B4
    B4 --> B5["paged KV cache"]
```

**After** — 커널이 slot mapping 을 그대로 받아 주소 계산을 안에서 합니다.

```mermaid
flowchart LR
    A1["GPU 스테이징 버퍼"] ==>|"slot mapping 직접 소비<br/>블록·칸 계산은 커널 안"| A2["paged KV cache"]
```

**바이트 이동과 주소 재배치를 나눈 2 단 구조는 그대로 둡니다.** 커널이 CXL 을 직접 읽으면 매체 읽기 내내 SM 을 붙잡아 같이 도는 디코드를 세우고, 그것을 피하는 것이 비동기 경로가 존재하는 이유입니다(동시 8 건 첫 토큰 599.7 → 470.2 ms, 토큰 간격 25.6 → 21.6 ms 로 확인된 축). 즉 이 PR 이 바꾸는 것은 **마지막 배치 단계의 구현 하나**입니다.

### 함께 들여오되 아직 쓰지 않는 것

칸 단위 배치 커널도 같이 가져왔지만 호출하지 않습니다. 자리 지정 단위를 토큰에서 칸으로 바꾸면 metadata 양과 커널 실행 갈래가 16 분의 1 이 되는 후속 축이 있고, 나중에 가져오면 빌드 설정을 두 번 건드려야 합니다. 그 전환의 A/B 판단 기준은 별도 설계 노트에 있습니다.

## 📝 Implementation Details

**패키지 (`maru_kv_ops/`)**

- `csrc/` — 상류에서 그대로 복사한 커널 소스 6 개(2,006 줄). `VENDOR.md` 에 리비전 40 자 커밋 id, 파일별 SHA-256, 상류가 그 뒤 무엇을 바꿨는지, 갱신 절차를 적었습니다.
- `csrc/pybind.cpp` — Maru 자신의 바인딩(90 줄). `multi_layer_kv_transfer`, `single_layer_kv_transfer`, `multi_layer_block_kv_transfer` 셋과 `TransferDirection`·`EngineKVFormat`·`PageBufferShapeDesc` 를 노출합니다. 형식은 12 개 전부 바인딩했습니다. 헤더 enum 이라 비용이 없고, 갱신으로 형식이 늘어도 이 파일을 안 건드립니다.
- `__init__.py` — `is_available()` / `import_error()`. **확장 import 전에 `import torch` 가 필요합니다.** 확장이 libtorch 에 링크되어 있어 그것이 로더 경로를 잡습니다. 이게 없으면 빌드가 성공해도 `libc10.so: cannot open shared object file` 로 import 가 실패합니다. 확장은 이름으로 import 합니다. 실행 중인 모듈의 서브모듈을 from-import 하면 미빌드 상태가 "circular import" 로 보고되는데, `import_error()` 는 운영자에게 그대로 인용되므로 원인을 정확히 말해야 합니다.
- `__getattr__` 로 미빌드 상태의 속성 접근이 빌드 단계를 지목한 `AttributeError` 를 냅니다.

**빌드와 설치 (`setup.py`, `install.sh`, 설치 문서)**

- `_kv_ops_extension()` 이 PyTorch import 가능성과 nvcc 존재를 먼저 확인한 뒤 `CUDAExtension` 을 만듭니다. nvcc 위치는 PyTorch 에게 물어봅니다. `CUDA_HOME` 만 설정돼 있고 그 안에 nvcc 가 없으면 PyTorch 의 검사가 예외를 내기 때문에, 게이트와 검사가 같은 것을 봐야 합니다.
- `_optional_kv_ops_build()` 가 PyTorch 의 전처리 검사를 빌드 전에 돌리고, 거부하면 확장만 빼고 남은 순수 C 확장을 기본 명령으로 빌드합니다.
- `MARU_SKIP_KV_OPS` 로 강제 생략이 가능합니다.
- `install.sh` 가 대상 환경의 PyTorch 유무로 `--no-build-isolation` 을 붙일지 판단하고, 설치 후 `is_available()` 로 결과를 보고합니다.
- 설치 문서에 「KV Placement Kernels」 절을 추가했고, vLLM 예제 문서 세 곳에 남아 있던 「LMCache is optional / `lmcache.c_ops` 를 재사용한다」 서술을 제거했습니다. 그 자리에는 Maru 자신의 커널을 만드는 설치 명령과 확인 한 줄이 들어갑니다.

**커넥터 (`maru_vllm/connector.py`)**

- `_resolve_kv_ops()` — 모듈 수준에서 한 번 해석하고 캐시합니다. 경고는 프로세스당 한 번입니다(로드마다 아님).
- `_packed_load_kernel_ctx` 의 `import lmcache.c_ops` 가 사라지고, `self._lmc_ops` 가 `self._kv_ops` 로 바뀝니다. 게이트(CUDA · Flash 레이아웃 · 형식 존재)는 그대로입니다.
- `_place_packed_layer()` 신설 — 커널 갈래와 폴백 갈래를 한자리에 모읍니다. 겹침 경로 두 곳(로더 스레드 발행, 재개된 forward 발행)이 이것을 씁니다.
- `_copy_packed_layer_to_device()` 의 스테이징 모양이 `[청크, 2, 토큰, hidden]` → `[2, 전체 토큰, hidden]` 으로 바뀝니다. 커널이 `token_major=False` 로 읽는 모양이고, 동시에 폴백이 `num_chunks=1` 로 읽는 모양이라 두 갈래가 한 배치를 공유합니다.
- `_packed_layer_copy_plan()` 으로 pitched 복사의 오프셋 산술을 떼어냈습니다. 텐서도 CUDA 도 쓰지 않습니다. **이 부분이 이 PR 에서 가장 위험합니다.** 오프셋이 틀리면 옆 레이어의 바이트를 복사하는데 로드는 성공으로 보고합니다. 떼어낸 덕에 테스트가 계획을 합성 슬랩에 재생해 바이트 단위로 검증할 수 있습니다.
- `_packed_store_kernel_ctx` 는 이름을 그대로 두고 docstring 을 고쳤습니다. 저장이 첫 사용자였지만 이제 「호출 시점에 레이어 목록이 없는 모든 경로」가 씁니다. 개명은 테스트까지 번져 diff 가 커지므로 분리했습니다. 다만 로그 메시지에서는 방향 표현을 뺐습니다. 이제 로드 경로가 첫 호출자가 될 수 있어서 저장을 한 번도 안 한 시점에 D2H 활성 로그가 찍히기 때문입니다.

**리뷰 지적 반영 (커밋 `5ca4929`, `6ef9f86`, `7fae1f6`, `f2837de`, `b5fb808`)**

- 문서화된 설치 경로가 커널을 만들지 않던 문제와, `optional=True` 가 전처리 검사 실패를 못 막던 문제를 위 설명대로 고쳤습니다.
- 벤더 리비전 테스트가 40 자 hex 존재만 확인해서 실제 드리프트를 못 잡던 것을 파일별 SHA-256 비교로 바꿨습니다.
- `single_layer_kv_transfer` 가 처리하는 형식 집합이 게이트보다 좁은데 아무 테스트도 그 관계를 고정하지 않던 것을, `mem_kernels.cu` 의 switch 와 `kv_layout.py` 의 형식 이름을 읽어 비교하는 테스트로 고정했습니다.
- `test_kv_ops.py` 가 모듈 최상단 `importorskip("torch")` 때문에 CI 에서 통째로 건너뛰어지던 것을 고쳐, 출처·형식 가드가 CI 에서 실제로 돕니다.
- 여러 청크를 가진 run 이 두 개 이상인 경우의 바이트 검증이 비어 있던 것을 채웠습니다.

## ✅ Tests

- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

**단위 테스트** — GPU 를 마스킹한 상태(`CUDA_VISIBLE_DEVICES=""`)로 확장을 빌드한 호스트에서 937 통과 / 12 skip. 확장이 없는 호스트에서는 927 통과 / 22 skip 이고, 늘어난 skip 은 바인딩 표면 테스트입니다. 커넥터 테스트는 183 → 196, `test_kv_ops.py` 30 개를 새로 추가했습니다.

신규 테스트가 고정하는 계약은 여섯입니다.

1. **커널 해석** — 빌드된 확장을 캐시하는지, 미빌드 시 경고가 한 번만 나가고 빌드 단계를 지목하는지, 그리고 미빌드가 폴백으로 이어지고 예외를 내지 않는지.
2. **오프셋 산술** — 복사 계획을 합성 슬랩에 재생해 「레이어 k 를 요청 토큰 순서로 모은 결과」와 바이트 단위로 비교합니다. 연속 run · 끊어진 run · 여러 청크를 가진 run 두 개 · 단일 청크 run 네 경우를 덮습니다.
3. **배치 두 갈래** — 커널 갈래가 `token_major=False` 로 넘기는지, 폴백 갈래가 `num_chunks=1` 로 넘기는지. 두 인자가 각각 스테이징 모양 해석을 결정합니다.
4. **출처 무결성** — 벤더 파일 6 개의 SHA-256 을 `VENDOR.md` 의 기록과 대조합니다. 새 바이트가 옛 리비전 id 아래 들어오는 것이 실제로 위험한 드리프트인데, 리비전 줄만으로는 잡히지 않습니다.
5. **형식 디스패치** — `kv_layout.py` 가 내보내는 형식 네 개가 `single_layer_kv_transfer` 의 switch 에 모두 있는지. 게이트는 enum 멤버 존재만 보므로, 갱신이나 새 layout 이 이 관계를 깨면 겹침 경로만 스트림 안에서 예외를 냅니다.
6. **갱신 드리프트** — 진입점·형식·인자 이름이 노출돼 있는지, SPDX 헤더 보존과 리비전 기록이 있는지.

**컴파일** — CUDA 13.0 / sm_120 으로 컴파일·링크 통과(경고 0). 상류 소스가 LMCache 고유 헤더 없이 단독으로 빌드됩니다. 바인딩 표면이 커넥터가 넘기는 인자 이름과 일치하는 것도 확인했습니다.

**설치 경로** — 깨끗한 트리에서 격리 빌드 wheel 에는 `maru_kv_ops/_C` 가 없고 `--no-build-isolation` wheel 에는 있습니다. CUDA 12.8 툴킷과 cu130 PyTorch 조합에서 전처리 검사 거부를 재현했고, 고친 뒤 같은 조건에서 확장만 빠지고 설치는 성공합니다. `install.sh` 는 PyTorch 있음·없음·확장 미생성 세 갈래를 모두 실행해 확인했습니다.

**타입 검사** — 오류 87 건으로 변경 전과 동일(신규 0). 린트·포맷·Sphinx 빌드 통과.

**실기 측정** — 기본 적재 경로는 `lmcache.c_ops` 빌드와 측정 분해능 안에서 같고(동시 8 건 요청당 적재 시간 두 구성 차이 +0.24 %, 같은 구성 안의 실행 간 흔들림 1.3 · 1.7 %), 겹침 적재는 레이어 배치를 발행하는 CPU 시간이 절반으로 줄면서 동시 8 건 첫 토큰이 13.3 % 짧아집니다. 동작 차이는 두 군데뿐입니다. 기본 적재 경로에서 `ops` 를 어느 모듈에서 얻는가, 그리고 겹침 적재의 배치 구현입니다.

설계 단계에서 기대치를 첫 토큰 개선 0 으로 잡아 두었으므로(전송이 계산보다 173 ms 먼저 끝나 이미 임계경로 밖이고, KV 배치는 레이어당 1 ms 미만), 기본 경로 측정의 목적은 개선 확인이 아니라 회귀 없음 확인입니다. 결과는 그 기대와 맞습니다.

*측정 조건* — 이 PR(`b5fb808`)과 main 병합 지점(`84a6aff`, `lmcache.c_ops` 를 쓰는 상태)을 번갈아 5 라운드 돌렸습니다. 한 라운드는 서버를 새로 띄운 독립 실행이고, 홀수 라운드는 이 PR 을 먼저·짝수 라운드는 기준선을 먼저 돌려(3 회 대 2 회) 시간에 따른 장비 상태 변화가 한쪽에만 쌓이지 않게 했습니다.

| 항목 | 값 |
|---|---|
| 장비 | NVIDIA RTX PRO 6000 Blackwell(sm_120) 1 장, CXL-DRAM `/dev/dax1.0` |
| 모델 | Qwen2.5-0.5B (24 레이어) |
| 프롬프트 | 동시 요청 슬롯마다 서로 다른 2,725 토큰(청크 256 기준 10 청크) |
| 절차 | 한 번 저장한 뒤 같은 프롬프트를 되읽기. 동시 1 건은 되읽기 10 회, 동시 8 건은 되읽기 5 회(회마다 8 건을 동시에 발사) |
| 코드 기본값과 다르게 켠 것 | `--gpu-memory-utilization 0.15`, `--no-enable-prefix-caching`, 응답 길이 32 토큰, `maru_pool_size=8G`, `maru_kv_chunk_tokens=256`, `maru_log_timing=true`, `MARU_PLUGINS=none`, `VLLM_USE_FLASHINFER_SAMPLER=0` |

GPU 메모리 비율 0.15 는 동시 8 건의 KV 여유와 스케줄링을 직접 좌우하므로 아래 수치를 읽을 때 함께 보아야 합니다. 절대값은 이 조건의 것이라, 이 본문 앞쪽이 인용한 다른 조건의 첫 토큰 수치(148 대 142.4 ms, 599.7 → 470.2 ms)와는 모델도 프롬프트도 달라 서로 비교할 수 없습니다.

*지표의 정체* — 네 가지를 씁니다.

- **요청당 적재 시간**: `packed-load wall`(CXL 읽기 + H2D + 배치 커널 + 스트림 동기화를 감싼 벽시계 시간)을 그 배치가 덮은 요청 수로 나눈 값. 한 배치가 덮는 요청 수가 실행마다 달라서 배치당 값끼리는 비교할 수 없습니다.
- **레이어 배치 발행 시간**: 겹침 경로에서 적재 스레드가 24 개 레이어의 스테이징 복사와 배치를 스트림에 밀어 넣는 데 쓴 CPU 시간을 요청 수로 나눈 값. GPU 실행 시간이 아니라 발행 비용입니다.
- **두 구성 차이**: 라운드마다 각 구성의 중앙값을 내고, 같은 라운드끼리 짝지어 구한 상대 차이. 그 5 개의 중앙값과 범위를 싣습니다. 앞의 ms 두 칸은 라운드 중앙값 5 개의 중앙값이라 **ms 두 칸을 나눈 값과 이 칸은 같지 않습니다.**
- **실행 간 흔들림**: 한 구성의 라운드별 중앙값 5 개에서 (최대−최소)÷중앙값. 「기준선 · 이 PR」 순으로 두 값을 적으며, 두 구성 차이를 읽을 때의 잡음 바닥입니다.

**기본 적재 경로(겹침 끔) — 측정 분해능 안에서 동등**

| 지표 (동시 건수) | 이 PR | 기준선 | 두 구성 차이 (중앙값) | 차이 범위 | 실행 간 흔들림 (기준선 · PR) |
|---|---|---|---|---|---|
| 요청당 적재 시간 (8) | 1.37 ms | 1.36 ms | +0.24 % | −0.55 ~ +1.05 % | 1.3 % · 1.7 % |
| 요청당 적재 시간 (1) | 1.42 ms | 1.42 ms | −0.34 % | −7.9 ~ +5.3 % | 9.5 % · 7.7 % |
| 첫 토큰 (8) | 50.13 ms | 49.84 ms | +0.73 % | −17.4 ~ +8.9 % | 29.0 % · 8.9 % |
| 첫 토큰 (1) | 15.37 ms | 15.12 ms | +0.41 % | −3.3 ~ +11.2 % | 16.2 % · 10.8 % |

판정 근거는 분해능이 가장 높은 지표입니다. **동시 8 건 요청당 적재 시간은 잡음 바닥이 1.3 · 1.7 % 인데 두 구성 차이가 +0.24 % 이고, 라운드별 차이의 부호가 라운드마다 뒤집힙니다.** 나머지 세 지표는 차이의 중앙값이 모두 해당 잡음 바닥보다 작습니다. 원래 통과 기준으로 적었던 첫 토큰 차이도 동시 8 건 +0.73 %, 동시 1 건 +0.41 % 로 1 % 안이지만, 첫 토큰은 잡음 바닥이 8.9~29.0 % 라서 그 지표만으로는 1 % 를 가릴 분해능이 없습니다.

이 결과는 기계어 수준에서 설명됩니다. 벤더링한 커널 소스 6 개가 측정 장비에 설치된 LMCache 체크아웃의 같은 파일과 바이트 단위로 동일하고, 두 확장에서 뽑은 sm_120 SASS 를 주소·인코딩 주석을 빼고 대조하면 **배치 커널 153 개(명령 39,120 개)가 전부 일치**합니다. 그중 72 개는 익명 네임스페이스 인스턴스화라 mangled name 에 번역 단위 해시가 들어가므로 그 해시를 정규화한 뒤 맞췄습니다. 커넥터가 실제로 부르는 것은 `load_and_reshape_multi_layer_kernel` 74 개와 `single_layer_kv_transfer_kernel` 5 개이고 모두 여기 포함됩니다. 기본 적재 경로에서 이 PR 이 바꾸는 것은 `ops` 를 어느 모듈에서 얻는가 하나뿐이며, 그 경로의 나머지 변경분은 주석과 docstring 입니다.

**겹침 적재 — 발행 비용 절반 감소, 동시 8 건 첫 토큰 −13.3 %**

| 지표 (동시 건수) | 이 PR | 기준선 | 두 구성 차이 (중앙값) | 차이 범위 | 실행 간 흔들림 (기준선 · PR) |
|---|---|---|---|---|---|
| 레이어 배치 발행 시간 (8) | 2.40 ms | 5.36 ms | −54.6 % | −57.7 ~ −51.3 % | 9.9 % · 16.9 % |
| 레이어 배치 발행 시간 (1) | 0.77 ms | 1.51 ms | −45.5 % | −50.7 ~ −43.2 % | 13.3 % · 13.0 % |
| 첫 토큰 (8) | 54.41 ms | 63.02 ms | −13.3 % | −19.1 ~ −10.5 % | 8.4 % · 8.7 % |
| 첫 토큰 (1) | 16.41 ms | 17.53 ms | −8.6 % | −14.6 ~ −4.3 % | 9.4 % · 13.4 % |

네 지표 모두 5 라운드가 전부 같은 부호입니다. 발행 시간 두 줄은 차이가 잡음 바닥의 세 배를 넘고, 동시 8 건 첫 토큰도 차이 범위 전체가 잡음 바닥 위에 있습니다. 동시 1 건 첫 토큰은 차이가 잡음 바닥과 비슷한 크기라 크기만으로는 약하지만, 5 라운드가 모두 같은 방향입니다.

원인은 발행 횟수입니다. 기준선은 레이어마다 목적지 주소를 GPU 텐서 두 개로 만든 뒤 PyTorch 범용 연산에 넘겨 레이어당 커널 3 회를 발행하는데, 이 PR 은 커널 1 회로 끝냅니다. 24 레이어 기준으로 요청당 발행이 72 회에서 24 회로 줄고, 그것이 발행 시간 절반 감소로 나타납니다. 다만 **발행 시간은 적재 스레드의 CPU 비용이므로 그 감소분이 곧 첫 토큰 단축은 아닙니다.** 첫 토큰 단축은 따로 측정한 결과이고, 발행 비용 감소는 그 메커니즘입니다.

이 표는 **겹침을 켠 두 구현을 비교한 것이지 겹침 켬·끔 비교가 아닙니다.** 이 조건에서 겹침 켬은 이 PR 안에서도 끔보다 느립니다. 같은 라운드끼리 짝지으면 동시 8 건 첫 토큰이 5 라운드 모두 겹침 쪽이 크고(라운드별 +1.7 ~ +11.8 %, 중앙값 +10.8 %), 동시 1 건은 5 라운드 중 4 개가 그렇습니다(중앙값 +11.4 %). 겹침의 순이득은 계산이 전송보다 큰 조건에서 나오므로 그 판정은 이 측정의 범위 밖입니다.

**기능 게이트** — 측정 40 회 실행 전부에서 저장 실패 0 건, 적재 미스 0 건, 재계산 0 건입니다. 경로 기록은 구성별로 나뉩니다.

- 기본 적재 경로 20 회: 적재 커널 호출이 동시 1 건 10 회·동시 8 건 40 회로 되읽기 요청 수와 정확히 같고, 폴백 기록은 없습니다. 두 구성이 동일합니다.
- 겹침 경로 20 회: 적재 스레드의 레이어 배치 발행 기록이 동시 1 건 10 회·동시 8 건 40 회로 요청 수와 같습니다. 두 구성이 동일합니다. 다만 `_place_packed_layer()` 는 커널 갈래와 폴백 갈래 어느 쪽도 로그를 남기지 않으므로, 이 20 회에 대해 커널 갈래를 **골랐다는 것 자체는 로그로 확인되지 않습니다.** 근거는 기동 시 `is_available()` 이 참이라는 것과 발행 시간이 절반으로 줄었다는 것입니다.

**기능 검증** — 같은 장비에서 아래 구성을 각각 띄웠습니다. 여섯 구성 모두 동시 1 건에서 냉·온 생성 텍스트가 일치했고 오류가 없었습니다.

| 구성 | 확인한 것 |
|---|---|
| 기본 적재 | 적재·저장이 `multi_layer_kv_transfer` 로 기록됨 |
| 겹침 켬 | 기동 시 `is_available()` 참, 겹침 적재가 요청마다 발행 기록을 남김 |
| 레이어별 저장 | `maru_use_layerwise=true` 경로에 회귀 없음 |
| 인스턴스 2 대 공유 | 한쪽이 저장하고 다른 쪽이 적재, 양쪽 모두 커널 경로로 기록됨 |
| `lmcache` 임포트 차단 | `import lmcache` 가 `ImportError` 를 내도록 막은 채 기동해도 적재·저장 모두 커널 경로로 기록되고 적중 성립 |
| 커널 부재 | `is_available()` 이 거짓일 때 예외 없이 레이어별 폴백으로 내려가고, 경고가 빌드 단계를 지목 |

동시 8 건에서는 냉·온 텍스트가 8 개 요청 중 4 개에서 갈립니다. **같은 갈림이 병합 전 main 에서도 같은 4 개 요청·같은 문자 위치(56, 54, 136, 56)에서 나오고, Maru 를 끄고 vLLM 자체 prefix cache 만 쓴 대조 실행에서도 그중 3 곳이 같은 위치에서 갈립니다.** 즉 동시 실행 시의 배치 비결정성이며 이 PR 이 만든 차이가 아닙니다. 텍스트 바이트 일치는 동시 실행에서 깨지는 판정 기준이라 단독 근거로 쓰지 않았습니다.

문서대로 설치한 환경에서의 기동도 확인했습니다. CUDA 13.0 툴체인으로 sm_90·sm_120 확장이 경고 없이 빌드되고 `is_available()` 이 참입니다.

**남는 한계** — 커널 경로와 레이어별 폴백을 런타임에 갈라 볼 설정 손잡이는 없습니다. 커널 경로는 쓸 수 있으면 무조건 기본이고, `MARU_SKIP_KV_OPS` 는 설치 시점 환경변수라 서빙 중 A/B 에 쓸 수 없습니다. 폴백 경로를 측정 대상으로 삼을 일이 생기면 별도 PR 에서 손잡이를 추가하는 것이 맞습니다.

병합 전 필요 항목으로 적었던 세 건 중 두 건(내부화 전후 비교, 문서대로 설치한 환경에서의 기동)은 위에 측정 결과가 있습니다. 나머지 한 건인 **겹침 켬·끔 이득 재확정은 이 PR 범위 밖으로 옮깁니다.** 위 측정이 보여주듯 그 판정은 계산이 전송보다 큰 조건을 골라야 성립하고, 겹침 이득의 대외 인용값을 확정하는 별도 후속과 같은 작업이기 때문입니다. 이 PR 이 책임지는 범위는 겹침을 켠 상태에서 배치 구현을 바꾼 것이 회귀가 아니라는 확인까지입니다.

`maru_kv_ops._C` 는 `TransferDirection`·`EngineKVFormat` 을 `lmcache.c_ops` 와 같은 pybind11 타입 이름으로 등록합니다. 그래서 한 프로세스가 둘 다 임포트하면 나중에 임포트한 쪽이 실패합니다. 측정 장비에서 양방향으로 재현했습니다. `lmcache.c_ops` 가 먼저 들어온 프로세스에서는 `maru_kv_ops.is_available()` 이 거짓이 되어 커넥터가 폴백으로 내려가고, 반대 순서에서는 LMCache 가 `Failed to import backend lmcache.c_ops: generic_type: type "TransferDirection" is already registered!` 를 남기고 자기 백엔드를 못 씁니다. lmcache 가 깔리지 않은 직결 커넥터 배포에서는 발생하지 않지만, 두 패키지가 함께 깔린 호스트에서는 임포트 순서 하나로 경로가 갈립니다. 두 enum 에 `py::module_local()` 을 붙이면 해결되므로 별도로 다루는 편이 좋겠습니다.

## 🔗 Related Issues (optional)
-

## 🌿 Related PRs (optional)
- #70 (base) — 레이어 겹침을 동시성 제한 없이 동작하게 만든 PR. 이 PR 이 바꾸는 겹침 경로가 거기서 온 것입니다.

## 📦 Release Note (for auto-generation / write in English)
### NEW
- maru_kv_ops: new package holding Maru's paged-KV placement kernels, vendored from LMCache under Apache-2.0 with the source revision, a per-file SHA-256 and the refresh procedure recorded in `maru_kv_ops/VENDOR.md`. Built only where PyTorch and nvcc are both present; `is_available()` reports whether the kernels can be called.
### CHANGED
- maru_vllm: the direct connector no longer depends on LMCache in any way. Nothing under `maru_vllm/` imports `lmcache`, so a change to that package's internal layout can no longer reach the connector's default KV copy path, and the `lmcache` package is not a runtime requirement of the LMCache-free connector. Behaviour and the kernel/fallback gates are unchanged.
- maru_vllm: the layer-overlap load places KV with `single_layer_kv_transfer` instead of PyTorch advanced indexing, which drops two index tensors and two kernel launches per layer and removes a scatter-implementation difference from every overlap on/off comparison. The staging tensor becomes `[2, num_tokens, hidden]`, which both the kernel and the per-layer fallback read directly.
- maru_vllm: an unavailable placement kernel now logs once per process naming the build step that fixes it, rather than a single line stating the import failed.
- install.sh installs with `--no-build-isolation` when the target environment has PyTorch, so the documented install builds the placement kernels instead of silently skipping them, and reports afterwards whether they are callable. A CUDA toolkit that PyTorch's preflight rejects now drops the extension instead of failing the install.
### FIXED
-
### IMPORTANT NOTES
- The kernels are a build product of this package, so an existing install has to be redone to get them: run `./install.sh`, or `pip install -e . --no-build-isolation` in an environment with PyTorch and the CUDA toolkit. A plain `pip install -e .` runs an isolated build that never sees PyTorch and skips them. Without them the connector runs its per-layer fallback, which measured 148 vs 142.4 ms on a single-request cache-hit load and turns a chunk's single store transfer into one per (chunk, layer). `python -c "import maru_kv_ops; print(maru_kv_ops.is_available())"` reports which path a deployment will take.
- The vendored revision is deliberately not upstream's latest: it is the revision the measured LMCache build was compiled from, so a vendored-vs-`lmcache.c_ops` comparison isolates the packaging change. Upstream has since added engine KV formats and refactored `EngineKVFormat` onto a `KVFormatSpec`, changing the API surface; adopting that needs its own on-device comparison. Because the sources are vendored, such a change is now a compile error at refresh time rather than a runtime crash.
- On-device measurement, five rounds alternating this PR with the pre-merge main, puts the default load path inside measurement resolution of the `lmcache.c_ops` build: per-request load time differs by +0.24% at concurrency 8, where the run-to-run spread within either configuration is 1.3% and 1.7%, and the per-round difference changes sign from round to round. The vendored sources compile to byte-identical sm_120 SASS across all 153 placement kernels, so that is expected rather than lucky. The layer-overlap load, whose placement changed from PyTorch advanced indexing to `single_layer_kv_transfer`, issues a layer's placement in about half the CPU time and lowers first-token latency by 13.3% at concurrency 8, with all five rounds between -10.5% and -19.1%. Cache hits, store failures, load misses and recomputes were identical across both configurations. Reconfirming the overlap on/off gain is left out of this PR; see the Tests section.

