### PR TITLE
feat(maru_vllm): run the load/compute overlap on the layerwise storage format

### DIFF
--- a/docs/source/integration/vllm.md
+++ b/docs/source/integration/vllm.md
@@ -271,8 +271,8 @@ object granularity.
 
 `maru_overlap_load_with_compute` works with either storage layout and
 requires `maru_async_load`; it pipelines a request's per-layer transfers
-against attention compute. Under the packed layout each layer is sliced out
-of the packed chunk slabs; under the layerwise layout each layer's own chunk
+against attention compute. Under the chunkwise layout each layer is sliced
+out of the chunkwise slabs; under the layerwise layout each layer's own chunk
 objects are gathered directly. Every (chunk, layer) key is still resolved
 before the request is released, so the layerwise layout pays its full
 metadata RPC volume up front — only the transfers overlap compute. The

--- a/docs/source/integration/vllm.md
+++ b/docs/source/integration/vllm.md
@@ -263,11 +263,11 @@ The two layouts differ throughout the store and load paths:
 | Store | one gathered D2H per chunk | one write per layer |
 | Load | whole slab per chunk, contiguous pages coalesced | one retrieve per (layer, chunk) |
 
-The key count is the practical difference: a 64k prompt on a 32-layer model
-resolves ~250 keys chunkwise versus ~8,000 layerwise, and that ratio carries
-straight into retrieve metadata RPC volume. Chunkwise is the default for that
-reason; layerwise remains available for deployments that need per-layer
-object granularity.
+The key count is the practical difference: layerwise resolves one key per
+(chunk, layer) instead of one per chunk, so both the key count and the
+retrieve metadata RPC volume grow by the model's layer count. Chunkwise is
+the default for that reason; layerwise remains available for deployments that
+need per-layer object granularity.
 
 `maru_overlap_load_with_compute` works with either storage layout and
 requires `maru_async_load`; it pipelines a request's per-layer transfers

--- a/docs/source/integration/vllm.md
+++ b/docs/source/integration/vllm.md
@@ -197,7 +197,7 @@ Asynchronous transfer settings, all opt-in:
 |-----------|------|---------|-------------|
 | `maru_async_load` | bool | `false` | Load cache hits on a background thread between steps instead of inside the forward pass |
 | `maru_async_store` | bool | `false` | Complete the store after the forward pass instead of on the last attention layer |
-| `maru_overlap_load_with_compute` | bool | `false` | Overlap a packed load's per-layer transfers with attention compute |
+| `maru_overlap_load_with_compute` | bool | `false` | Overlap an async load's per-layer transfers with attention compute (either storage format) |
 
 Storage format — how a request's KV is grouped into CXL objects:
 
@@ -264,15 +264,20 @@ The two layouts differ throughout the store and load paths:
 | Load | whole slab per chunk, contiguous pages coalesced | one retrieve per (layer, chunk) |
 
 The key count is the practical difference: a 64k prompt on a 32-layer model
-resolves 59 keys chunkwise versus 1,888 layerwise, and that ratio carries
+resolves ~250 keys chunkwise versus ~8,000 layerwise, and that ratio carries
 straight into retrieve metadata RPC volume. Chunkwise is the default for that
 reason; layerwise remains available for deployments that need per-layer
 object granularity.
 
-`maru_overlap_load_with_compute` applies only to the packed layout and
+`maru_overlap_load_with_compute` works with either storage layout and
 requires `maru_async_load`; it pipelines a request's per-layer transfers
-against attention compute. The connector logs a warning and disables it when
-those prerequisites are not met.
+against attention compute. Under the packed layout each layer is sliced out
+of the packed chunk slabs; under the layerwise layout each layer's own chunk
+objects are gathered directly. Every (chunk, layer) key is still resolved
+before the request is released, so the layerwise layout pays its full
+metadata RPC volume up front — only the transfers overlap compute. The
+connector logs a warning and disables the knob when `maru_async_load` is
+off.
 
 ![Layerwise overlap: without overlap compute waits for the whole transfer; with overlap it starts once layer 1 has arrived, so compute fits inside the transfer and the transfer time is what remains as the floor; giving each request its own stream splits the bandwidth and raises that floor](../image/layerwise_overlap_concept.png)
 

--- a/maru_vllm/connector.py
+++ b/maru_vllm/connector.py
@@ -698,8 +698,8 @@ class MaruSchedulerConnector:
         # Deferred-hit requests that are still live in the scheduler. Pending
         # admissions alone are not a concurrency signal: a burst may arrive
         # one request per scheduler step while earlier requests are decoding.
-        # Keep the live set until finish/preemption so packed-layerwise is used
-        # only when the serving workload is actually singleton.
+        # Keep the live set until finish/preemption so the layerwise overlap is
+        # used only when the serving workload is actually singleton.
         self._active_deferred_req_ids: set[str] = set()
         # Requests emitted for deferred packed loading remain here until vLLM's
         # second update_state_after_alloc call says they are ready to resume.
@@ -1135,7 +1135,7 @@ class MaruWorkerConnector:
         # copies queued after the abort was seen.
         self._inflight_deferred_req_ids: set[str] = set()
         self._abandoned_req_ids: set[str] = set()
-        # True-async deferred loads (packed path): a single background thread
+        # True-async deferred loads: a single background thread
         # runs the whole load — Maru retrieve RPC + H2D on _deferred_stream —
         # so neither the RPC wait nor the copy blocks the engine thread's
         # forward passes (the in-process analog of MP's separate-process
@@ -1403,7 +1403,7 @@ class MaruWorkerConnector:
                     for layer_name, event in pre_issued.items():
                         self._layer_load_events.setdefault(layer_name, []).append(event)
             if issue_here:
-                self._schedule_deferred_packed_layerwise_loads(
+                self._schedule_deferred_layerwise_loads(
                     layers,
                     issue_here,
                     attn_metadata,
@@ -1423,8 +1423,8 @@ class MaruWorkerConnector:
                 self._fail_deferred_load(req_meta)
                 continue
 
-            # Packed deferred loads run off-thread. The default path performs
-            # retrieve + whole-request H2D there; packed layerwise overlap
+            # Deferred loads run off-thread. The default path performs
+            # retrieve + whole-request H2D there; the layerwise overlap
             # performs only retrieve and lets the resumed forward activate
             # per-layer H2D events. Falls through to the synchronous path
             # when the async prerequisites are missing. Layerwise-format
@@ -1434,7 +1434,7 @@ class MaruWorkerConnector:
             if (
                 req_meta.deferred_load
                 and (not self._use_layerwise or req_meta.layerwise_load)
-                and self._try_submit_deferred_packed_load(req_meta)
+                and self._try_submit_deferred_load(req_meta)
             ):
                 continue
 
@@ -1539,8 +1539,8 @@ class MaruWorkerConnector:
                 req_meta.req_id,
             )
 
-    def _try_submit_deferred_packed_load(self, req_meta: MaruReqMeta) -> bool:
-        """Hand a packed deferred load to the background loader thread.
+    def _try_submit_deferred_load(self, req_meta: MaruReqMeta) -> bool:
+        """Hand a deferred load to the background loader thread.
 
         Returns:
             True when the load was submitted. False when the async path
@@ -1573,11 +1573,11 @@ class MaruWorkerConnector:
         with self._deferred_lock:
             self._inflight_deferred_req_ids.add(req_meta.req_id)
         self._deferred_executor.submit(
-            self._deferred_packed_load_job, req_meta, layers, device
+            self._deferred_load_job, req_meta, layers, device
         )
         return True
 
-    def _deferred_packed_load_job(
+    def _deferred_load_job(
         self,
         req_meta: MaruReqMeta,
         layers: list[tuple[str, torch.Tensor, int]],
@@ -1953,7 +1953,7 @@ class MaruWorkerConnector:
                             infos[true_idx], num_chunks, kv_cache_layer
                         )
                     else:
-                        layer_dev = self._copy_packed_layer_to_device(
+                        layer_dev = self._copy_chunkwise_layer_to_device(
                             infos, num_chunks, true_idx, kv_cache_layer, stream
                         )
                     self._inject_kv_into_layer(
@@ -1994,7 +1994,7 @@ class MaruWorkerConnector:
                     pass
             return None
 
-    def _schedule_deferred_packed_layerwise_loads(
+    def _schedule_deferred_layerwise_loads(
         self,
         layers: list[tuple[str, torch.Tensor, int]],
         req_ids: set[str],
@@ -2103,7 +2103,7 @@ class MaruWorkerConnector:
                                 infos[true_idx], num_chunks, kv_cache_layer
                             )
                         else:
-                            layer_dev = self._copy_packed_layer_to_device(
+                            layer_dev = self._copy_chunkwise_layer_to_device(
                                 infos,
                                 num_chunks,
                                 true_idx,
@@ -2158,7 +2158,7 @@ class MaruWorkerConnector:
                 f"{(time.monotonic() - _t0) * 1000:.2f} ms"
             )
 
-    def _copy_packed_layer_to_device(
+    def _copy_chunkwise_layer_to_device(
         self,
         infos: list[Any],
         num_chunks: int,
@@ -2166,14 +2166,16 @@ class MaruWorkerConnector:
         kv_cache_layer: torch.Tensor,
         stream: torch.cuda.Stream,
     ) -> torch.Tensor:
-        """DMA one layer from packed chunk pages into one device tensor.
+        """DMA one layer from chunkwise pages into one device tensor.
 
-        One packed page is ``[2, layers, tokens, hidden]``. For a contiguous
-        page run, each layer's K (or V) plane is a fixed-width row separated
-        by one page pitch. Two ``cudaMemcpy2DAsync`` calls gather every chunk
-        directly from registered CXL into ``[chunks, 2, tokens, hidden]``.
-        The caller can then inject all chunks with one kernel. Gapped page
-        allocations become multiple pitched runs but keep the same output.
+        A chunkwise page packs every layer of one chunk into
+        ``[2, layers, tokens, hidden]``, so one layer is strided. For a
+        contiguous page run, each layer's K (or V) plane is a fixed-width row
+        separated by one page pitch. Two ``cudaMemcpy2DAsync`` calls gather
+        every chunk directly from registered CXL into
+        ``[chunks, 2, tokens, hidden]``. The caller can then inject all chunks
+        with one kernel. Gapped page allocations become multiple pitched runs
+        but keep the same output.
         """
         if not infos or num_chunks <= 0:
             raise ValueError("packed layer copy requires at least one chunk")

--- a/maru_vllm/connector.py
+++ b/maru_vllm/connector.py
@@ -446,13 +446,13 @@ class MaruKVConnector(KVConnectorBase_V1):
             completion marker). True is layerwise: one object per
             (chunk, layer), keyed <chunk>_L<idx>, with a separate _DONE
             marker. Chunkwise resolves one key per chunk instead of
-            chunks x layers — ~250 vs ~8,000 keys for a 64k prompt on 32
-            layers — which is why it is the default; the same ratio applies to
-            retrieve metadata RPC volume. Chunkwise transfers use LMCache's
-            multi_layer_kv_transfer kernel directly on the pinned CXL slab
-            (no staging) when available — load scatters a whole slab into the
-            paged cache per chunk, store gathers one D2H per chunk — falling
-            back to per-layer copies otherwise. See design note P6.
+            chunks x layers, so layerwise multiplies both the key count and
+            the retrieve metadata RPC volume by the model's layer count —
+            which is why chunkwise is the default. Chunkwise transfers use
+            LMCache's multi_layer_kv_transfer kernel directly on the pinned
+            CXL slab (no staging) when available — load scatters a whole slab
+            into the paged cache per chunk, store gathers one D2H per chunk —
+            falling back to per-layer copies otherwise. See design note P6.
 
     Diagnostics and fallback guards — leave these alone in normal operation:
         maru_load_admission_window: int - With maru_async_load, cap how many
@@ -1344,9 +1344,8 @@ class MaruWorkerConnector:
         P1 (batch retrieve): all ``(layer x chunk)`` keys of a request are
         fetched with a single batched ``batch_retrieve`` (payload-bounded RPC
         chunks) instead of one RPC per ``(layer, chunk)``. This collapses
-        ``num_layers x num_chunks`` single retrieves (e.g. ~8,000 for a 64k
-        prompt on a 32-layer model) into a few batched calls; that per-op RPC
-        round-trip dominated cache-hit TTFT/TPOT.
+        ``num_layers x num_chunks`` single retrieves into a few batched
+        calls; that per-op RPC round-trip dominated cache-hit TTFT/TPOT.
         """
         # Step boundary: per-step store state must not leak into this step,
         # even when this method bails out early below. A carried-over
@@ -2549,10 +2548,10 @@ class MaruWorkerConnector:
         whole to LMCache's ``multi_layer_kv_transfer``, which reads the pinned
         CXL host memory directly (UVA) and scatters all layers into the paged
         GPU cache in one kernel per chunk — the same no-staging path LMCache's
-        ``VLLMPagedMemGPUConnectorV2.to_gpu`` uses. This avoids both v1's ~8,000
-        tiny copies and the reverted GPU-staging OOM. Non-Flash layouts, CPU,
-        or a missing ``lmcache.c_ops`` fall back to a per-layer inject that
-        reads the same slab slices.
+        ``VLLMPagedMemGPUConnectorV2.to_gpu`` uses. This avoids both v1's
+        per-(layer, chunk) copies and the reverted GPU-staging OOM. Non-Flash
+        layouts, CPU, or a missing ``lmcache.c_ops`` fall back to a per-layer
+        inject that reads the same slab slices.
 
         Deferred (between-step) requests are marked finished immediately (the
         transfer completes on the current stream before this returns).
@@ -2565,7 +2564,7 @@ class MaruWorkerConnector:
         # Queue all per-chunk transfers on a dedicated high-priority stream and
         # sync once at the end — mirrors LMCache batched_to_gpu (per-chunk
         # multi_layer_kv_transfer on its load_stream, one synchronize). Keeps
-        # the ~250 launches pipelined instead of serializing on the compute
+        # the per-chunk launches pipelined instead of serializing on the compute
         # stream. Falls back to the current stream on CPU/non-CUDA.
         dev = layers[0][1].device
         use_stream = kernel is not None or (

--- a/maru_vllm/connector.py
+++ b/maru_vllm/connector.py
@@ -232,7 +232,7 @@ def _load_keys(
 ) -> list[str]:
     """Retrieve keys for one request's matched chunks.
 
-    Packed: one key per chunk. Layerwise: one key per (chunk, layer),
+    Chunkwise: one key per chunk. Layerwise: one key per (chunk, layer),
     layer-major in the caller's own layer order — consumers must index the
     result with that same order (or re-key by true layer index).
     """
@@ -432,8 +432,8 @@ class MaruKVConnector(KVConnectorBase_V1):
             parked request's per-layer transfers while it waits and release
             it once its first layer has landed, so the remaining layers
             arrive during its own attention. Works under either storage
-            format: packed slabs are sliced per layer, layerwise objects are
-            gathered per layer. The transfers share one stream, which keeps
+            format: chunkwise slabs are sliced per layer, layerwise objects
+            are gathered per layer. The transfers share one stream, which keeps
             each at full bandwidth and makes a later request's first layer
             land only after the earlier one has finished. Applies at any
             concurrency. Requires maru_async_load=true
@@ -1156,8 +1156,8 @@ class MaruWorkerConnector:
         # Overlap loads whose off-thread copy issue failed: the loader thread
         # resolved the RPC/mmap metadata and the resumed forward consumes
         # these entries layer-by-layer on _load_stream. The retained views are
-        # a flat per-chunk list of packed slabs, or (under maru_use_layerwise)
-        # a dict keyed by true layer index.
+        # a flat per-chunk list of chunkwise slabs, or (under
+        # maru_use_layerwise) a dict keyed by true layer index.
         self._deferred_layerwise_loads: dict[
             str,
             tuple[MaruReqMeta, int, torch.Tensor, list[Any] | dict[int, list[Any]]],
@@ -1431,7 +1431,7 @@ class MaruWorkerConnector:
             # when the async prerequisites are missing. Layerwise-format
             # requests go off-thread only when the scheduler marked them for
             # overlap — the job's whole-request branch only understands
-            # packed slabs.
+            # chunkwise slabs.
             if (
                 req_meta.deferred_load
                 and (not self._use_layerwise or req_meta.layerwise_load)
@@ -1590,7 +1590,7 @@ class MaruWorkerConnector:
         socket use internally, so retrieving here while the engine thread
         stores is safe. The default mode also performs H2D and records a CUDA
         event. Layerwise-overlap mode stops after retrieve and retains the CXL
-        views (packed slabs, or per-(chunk,layer) objects under
+        views (chunkwise slabs, or per-(chunk,layer) objects under
         ``maru_use_layerwise``) for the resumed forward. Any failure reports
         the request's blocks through ``take_failed_load_blocks`` so vLLM
         recomputes instead of consuming unloaded KV.
@@ -1603,7 +1603,7 @@ class MaruWorkerConnector:
                 self._fail_deferred_load(req_meta)
                 return
             if self._use_layerwise and not req_meta.layerwise_load:
-                # The whole-request branch below only understands packed
+                # The whole-request branch below only understands chunkwise
                 # slabs; the submit gate never sends this combination, so a
                 # request reaching it means a wiring bug — recompute instead,
                 # and say so: silently failing here would present as a
@@ -1926,7 +1926,7 @@ class MaruWorkerConnector:
             req_meta: Metadata of the parked request.
             num_chunks: Chunks matched for this request.
             slot_mapping: Host slot mapping covering those chunks.
-            infos: Retrieved CXL views — a flat per-chunk list of packed
+            infos: Retrieved CXL views — a flat per-chunk list of chunkwise
                 slabs, or (under ``maru_use_layerwise``) a dict keyed by true
                 layer index holding that layer's per-chunk objects.
             layers: (layer_name, paged kv tensor, layer index) for every layer.
@@ -2005,7 +2005,7 @@ class MaruWorkerConnector:
 
         The background loader already completed Maru RPC/mmap lookup. This
         method runs at the beginning of the resumed forward: for layer k it
-        copies only that layer's KV — sliced from every packed CXL slab, or
+        copies only that layer's KV — sliced from every chunkwise CXL slab, or
         (under ``maru_use_layerwise``) gathered from that layer's own chunk
         objects — into paged KV on ``_load_stream``, and records an event.
         Attention layer k waits for only that event, leaving layer k+1

--- a/maru_vllm/connector.py
+++ b/maru_vllm/connector.py
@@ -311,10 +311,10 @@ class MaruReqMeta:
     # For load: the request is parked in WAITING_FOR_REMOTE_KVS and the worker
     # loads between scheduler steps, reporting completion via get_finished().
     deferred_load: bool = False
-    # Adaptive packed-layerwise mode: the loader thread stops after retrieve
-    # and the resumed forward pipelines this request by layer. Scheduler sets
-    # this only for a singleton deferred-admission batch; at higher admission
-    # concurrency the completed whole-request background DMA remains faster.
+    # Layerwise-overlap mode: the loader thread stops after retrieve and the
+    # resumed forward pipelines this request by layer. Set for every deferred
+    # load when maru_overlap_load_with_compute is on, under either storage
+    # format.
     layerwise_load: bool = False
     # Per-step memo of _chunk_keys(token_ids). The same MaruReqMeta object is
     # shared across a step's per-layer save_kv_layer calls (and the step's
@@ -349,9 +349,9 @@ class MaruConnectorMetadata(KVConnectorMetadata):
     # the connector reports its load complete, so the worker must drain the
     # copies it queued for that request before that report goes out.
     finished_req_ids: set[str] = field(default_factory=set)
-    # Deferred packed loads whose metadata RPC completed between steps. The
-    # resumed forward consumes their CXL views layer-by-layer, so layer k+1 H2D
-    # can overlap layer k compute without changing the packed storage format.
+    # Deferred loads whose metadata RPC completed between steps. The resumed
+    # forward consumes their CXL views layer-by-layer, so layer k+1 H2D can
+    # overlap layer k compute regardless of the storage format.
     layerwise_load_req_ids: set[str] = field(default_factory=set)
 
 
@@ -397,14 +397,15 @@ class MaruKVConnector(KVConnectorBase_V1):
             background thread; finished requests retain their GPU blocks until
             get_finished() reports the store complete
             (default: false; was maru_enable_write_behind)
-        maru_overlap_load_with_compute: bool - With maru_async_load and packed
-            storage, queue a parked request's per-layer transfers while it
-            waits and release it once its first layer has landed, so the
-            remaining layers arrive during its own attention. The transfers
-            share one stream, which keeps each at full bandwidth and makes a
-            later request's first layer land only after the earlier one has
-            finished. Applies at any concurrency. Requires
-            maru_async_load=true and maru_use_layerwise=false
+        maru_overlap_load_with_compute: bool - With maru_async_load, queue a
+            parked request's per-layer transfers while it waits and release
+            it once its first layer has landed, so the remaining layers
+            arrive during its own attention. Works under either storage
+            format: packed slabs are sliced per layer, layerwise objects are
+            gathered per layer. The transfers share one stream, which keeps
+            each at full bandwidth and makes a later request's first layer
+            land only after the earlier one has finished. Applies at any
+            concurrency. Requires maru_async_load=true
             (default: false; was maru_enable_layerwise_overlap)
 
     Storage format — how a request's KV is grouped into CXL objects:
@@ -414,8 +415,8 @@ class MaruKVConnector(KVConnectorBase_V1):
             completion marker). True is layerwise: one object per
             (chunk, layer), keyed <chunk>_L<idx>, with a separate _DONE
             marker. Chunkwise resolves one key per chunk instead of
-            chunks x layers — 59 vs 1,888 keys for a 64k prompt on 32 layers
-            — which is why it is the default; the same ratio applies to
+            chunks x layers — ~250 vs ~8,000 keys for a 64k prompt on 32
+            layers — which is why it is the default; the same ratio applies to
             retrieve metadata RPC volume. Chunkwise transfers use LMCache's
             multi_layer_kv_transfer kernel directly on the pinned CXL slab
             (no staging) when available — load scatters a whole slab into the
@@ -654,15 +655,10 @@ class MaruSchedulerConnector:
         overlap_requested = bool(
             _get_knob(extra_config, "maru_overlap_load_with_compute")
         )
-        self._layerwise_overlap = bool(
-            overlap_requested and self._deferred_loading and not self._use_layerwise
-        )
-        if overlap_requested and not (
-            self._deferred_loading and not self._use_layerwise
-        ):
+        self._layerwise_overlap = bool(overlap_requested and self._deferred_loading)
+        if overlap_requested and not self._deferred_loading:
             logger.warning(
-                "Maru packed-layerwise overlap requires maru_async_load=true and "
-                "maru_use_layerwise=false; disabling it"
+                "Maru layerwise overlap requires maru_async_load=true; disabling it"
             )
         # Deferred loads registered by update_state_after_alloc, emitted once
         # by the next build_connector_meta. req_id -> (request,
@@ -1150,19 +1146,16 @@ class MaruWorkerConnector:
         # into one CXL object with one key — matching LMCache use_layerwise=
         # False — so a request resolves num_chunks keys instead of
         # num_chunks x num_layers. Layerwise=True keeps the per-(chunk,layer)
-        # objects and the layer-wise async overlap path.
+        # objects. The overlap path below works under either format.
         self._use_layerwise = bool(extra_config.get("maru_use_layerwise", False))
         async_load = bool(_get_knob(extra_config, "maru_async_load"))
         overlap_requested = bool(
             _get_knob(extra_config, "maru_overlap_load_with_compute")
         )
-        self._layerwise_overlap = bool(
-            overlap_requested and async_load and not self._use_layerwise
-        )
-        if overlap_requested and not (async_load and not self._use_layerwise):
+        self._layerwise_overlap = bool(overlap_requested and async_load)
+        if overlap_requested and not async_load:
             logger.warning(
-                "Maru packed-layerwise overlap requires maru_async_load=true and "
-                "maru_use_layerwise=false; disabling it"
+                "Maru layerwise overlap requires maru_async_load=true; disabling it"
             )
         # Packed store accumulates a chunk's per-layer slices across the
         # per-layer save_kv_layer calls of one step: base_key -> (handle,
@@ -1400,11 +1393,14 @@ class MaruWorkerConnector:
             # Packed deferred loads run off-thread. The default path performs
             # retrieve + whole-request H2D there; packed layerwise overlap
             # performs only retrieve and lets the resumed forward activate
-            # per-layer H2D events. Falls through to the synchronous packed
-            # path when the async prerequisites are missing.
+            # per-layer H2D events. Falls through to the synchronous path
+            # when the async prerequisites are missing. Layerwise-format
+            # requests go off-thread only when the scheduler marked them for
+            # overlap — the job's whole-request branch only understands
+            # packed slabs.
             if (
                 req_meta.deferred_load
-                and not self._use_layerwise
+                and (not self._use_layerwise or req_meta.layerwise_load)
                 and self._try_submit_deferred_packed_load(req_meta)
             ):
                 continue
@@ -1548,15 +1544,16 @@ class MaruWorkerConnector:
         layers: list[tuple[str, torch.Tensor, int]],
         device: torch.device,
     ) -> None:
-        """Prepare one parked request's packed KV off-thread.
+        """Prepare one parked request's KV off-thread.
 
         Runs on the deferred-load thread. The Maru RPC client serializes
         socket use internally, so retrieving here while the engine thread
         stores is safe. The default mode also performs H2D and records a CUDA
-        event. Packed-layerwise mode stops after retrieve and retains the CXL
-        views for the resumed forward. Any failure reports the request's
-        blocks through ``take_failed_load_blocks`` so vLLM recomputes instead
-        of consuming unloaded KV.
+        event. Layerwise-overlap mode stops after retrieve and retains the CXL
+        views (packed slabs, or per-(chunk,layer) objects under
+        ``maru_use_layerwise``) for the resumed forward. Any failure reports
+        the request's blocks through ``take_failed_load_blocks`` so vLLM
+        recomputes instead of consuming unloaded KV.
         """
         try:
             handler = self._handler
@@ -1565,9 +1562,25 @@ class MaruWorkerConnector:
             if handler is None or num_chunks == 0:
                 self._fail_deferred_load(req_meta)
                 return
+            if self._use_layerwise and not req_meta.layerwise_load:
+                # The whole-request branch below only understands packed
+                # slabs; the submit gate never sends this combination, so a
+                # request reaching it means a wiring bug — recompute instead.
+                self._fail_deferred_load(req_meta)
+                return
             total_tokens = num_chunks * self._kv_chunk_tokens
             slot_mapping = self._build_slot_mapping(req_meta.block_ids, total_tokens)
-            keys = [chunk_keys[ci] for ci in range(num_chunks)]
+            if self._use_layerwise:
+                # One key per (chunk, layer), layer-major, in this job's own
+                # layer order — consumers index the retained dict by true
+                # layer index, never by list position.
+                keys = [
+                    f"{chunk_keys[ci]}_L{layer_idx}"
+                    for (_, _, layer_idx) in layers
+                    for ci in range(num_chunks)
+                ]
+            else:
+                keys = [chunk_keys[ci] for ci in range(num_chunks)]
 
             _t0 = time.monotonic()
             infos = self._batch_retrieve_all(keys)
@@ -1589,11 +1602,20 @@ class MaruWorkerConnector:
             if req_meta.layerwise_load:
                 # The RPC/mmap part is complete. Either queue the per-layer
                 # copies here, while the request is still parked, or retain
-                # the packed CXL views so the resumed forward issues them.
-                # Either way the packed keys/pages are preserved and the bulk
-                # load overlaps the request's own compute.
+                # the CXL views so the resumed forward issues them. Either
+                # way the keys/pages are preserved and the bulk load overlaps
+                # the request's own compute.
+                payload: Any = infos
+                if self._use_layerwise:
+                    # Key by true layer index: the resumed forward walks its
+                    # own no_compile_layers order, which need not match this
+                    # job's layer list.
+                    payload = {
+                        true_idx: infos[li * num_chunks : (li + 1) * num_chunks]
+                        for li, (_, _, true_idx) in enumerate(layers)
+                    }
                 events = self._issue_layerwise_copies_offthread(
-                    req_meta, num_chunks, slot_mapping, infos, layers, device
+                    req_meta, num_chunks, slot_mapping, payload, layers, device
                 )
                 gate = (
                     self._unpark_gate_event(events, layers)
@@ -1620,7 +1642,7 @@ class MaruWorkerConnector:
                                 req_meta,
                                 num_chunks,
                                 slot_mapping,
-                                infos,
+                                payload,
                             )
                         if events is None or gate is None:
                             self._deferred_done.add(req_meta.req_id)
@@ -1851,7 +1873,9 @@ class MaruWorkerConnector:
             req_meta: Metadata of the parked request.
             num_chunks: Chunks matched for this request.
             slot_mapping: Host slot mapping covering those chunks.
-            infos: Retrieved CXL views, one per chunk.
+            infos: Retrieved CXL views — a flat per-chunk list of packed
+                slabs, or (under ``maru_use_layerwise``) a dict keyed by true
+                layer index holding that layer's per-chunk objects.
             layers: (layer_name, paged kv tensor, layer index) for every layer.
             device: CUDA device holding the paged KV.
 
@@ -1872,9 +1896,14 @@ class MaruWorkerConnector:
             with torch.cuda.stream(stream):
                 slot_gpu = pinned.to(device, non_blocking=True)
                 for layer_name, kv_cache_layer, true_idx in layers:
-                    layer_dev = self._copy_packed_layer_to_device(
-                        infos, num_chunks, true_idx, kv_cache_layer, stream
-                    )
+                    if self._use_layerwise:
+                        layer_dev = self._copy_layerwise_layer_to_device(
+                            infos[true_idx], num_chunks, kv_cache_layer
+                        )
+                    else:
+                        layer_dev = self._copy_packed_layer_to_device(
+                            infos, num_chunks, true_idx, kv_cache_layer, stream
+                        )
                     self._inject_kv_into_layer(
                         kv_cache_layer,
                         layer_dev,
@@ -1919,14 +1948,16 @@ class MaruWorkerConnector:
         req_ids: set[str],
         attn_metadata: AttentionMetadata | None,
     ) -> None:
-        """Activate retrieved packed slabs as a layer-major H2D pipeline.
+        """Activate retained CXL views as a layer-major H2D pipeline.
 
         The background loader already completed Maru RPC/mmap lookup. This
         method runs at the beginning of the resumed forward: for layer k it
-        copies only that layer's K/V slices from every packed CXL slab, injects
-        them into paged KV on ``_load_stream``, and records an event. Attention
-        layer k waits for only that event, leaving layer k+1 transfer queued in
-        parallel with layer k compute. No device-wide synchronize is used.
+        copies only that layer's KV — sliced from every packed CXL slab, or
+        (under ``maru_use_layerwise``) gathered from that layer's own chunk
+        objects — into paged KV on ``_load_stream``, and records an event.
+        Attention layer k waits for only that event, leaving layer k+1
+        transfer queued in parallel with layer k compute. No device-wide
+        synchronize is used.
         """
         entries: list[tuple[MaruReqMeta, int, torch.Tensor, list[Any]]] = []
         missing: list[str] = []
@@ -1948,22 +1979,31 @@ class MaruWorkerConnector:
         devices = {layer.device for _, layer, _ in layers}
         device = next(iter(devices)) if len(devices) == 1 else None
         if device is None or device.type != "cuda" or not torch.cuda.is_available():
-            # Correctness fallback for CPU/mixed layouts. It preserves packed
-            # storage but cannot overlap because there is no common CUDA stream.
+            # Correctness fallback for CPU/mixed layouts. It preserves the
+            # storage format but cannot overlap because there is no common
+            # CUDA stream.
             for req_meta, num_chunks, slot_mapping, infos in entries:
                 try:
                     for layer_name, kv_cache_layer, true_idx in layers:
                         for ci in range(num_chunks):
-                            slab_host = torch.frombuffer(
-                                infos[ci].view, dtype=kv_cache_layer.dtype
-                            ).view(2, self._num_layers, self._kv_chunk_tokens, -1)
+                            if self._use_layerwise:
+                                layer_host = torch.frombuffer(
+                                    infos[true_idx][ci].view,
+                                    dtype=kv_cache_layer.dtype,
+                                )
+                            else:
+                                layer_host = torch.frombuffer(
+                                    infos[ci].view, dtype=kv_cache_layer.dtype
+                                ).view(2, self._num_layers, self._kv_chunk_tokens, -1)[
+                                    :, true_idx
+                                ]
                             chunk_start = ci * self._kv_chunk_tokens
                             chunk_slots = slot_mapping[
                                 chunk_start : chunk_start + self._kv_chunk_tokens
                             ]
                             self._inject_kv_into_layer(
                                 kv_cache_layer,
-                                slab_host[:, true_idx].to(kv_cache_layer.device),
+                                layer_host.to(kv_cache_layer.device),
                                 chunk_slots.to(kv_cache_layer.device),
                                 attn_metadata,
                                 layer_name,
@@ -2004,13 +2044,18 @@ class MaruWorkerConnector:
                     for (_, num_chunks, _, infos), slot_gpu in zip(
                         entries, slot_mappings_gpu, strict=True
                     ):
-                        layer_dev = self._copy_packed_layer_to_device(
-                            infos,
-                            num_chunks,
-                            true_idx,
-                            kv_cache_layer,
-                            load_stream,
-                        )
+                        if self._use_layerwise:
+                            layer_dev = self._copy_layerwise_layer_to_device(
+                                infos[true_idx], num_chunks, kv_cache_layer
+                            )
+                        else:
+                            layer_dev = self._copy_packed_layer_to_device(
+                                infos,
+                                num_chunks,
+                                true_idx,
+                                kv_cache_layer,
+                                load_stream,
+                            )
                         self._inject_kv_into_layer(
                             kv_cache_layer,
                             layer_dev,
@@ -2125,6 +2170,37 @@ class MaruWorkerConnector:
                 if error != 0:
                     raise RuntimeError(f"cudaMemcpy2DAsync failed with code {error}")
         return layer_dev
+
+    def _copy_layerwise_layer_to_device(
+        self,
+        layer_infos: list[Any],
+        num_chunks: int,
+        kv_cache_layer: torch.Tensor,
+    ) -> torch.Tensor:
+        """Gather one layer's per-(chunk,layer) objects into one flat tensor.
+
+        Layerwise objects are single-layer and contiguous, so no pitched copy
+        is needed: each ``_chunk_runs`` run becomes one contiguous H2D copy.
+        ``copy_`` enqueues on the current stream, so CUDA callers must run
+        inside a ``torch.cuda.stream(...)`` context. The flat
+        ``num_chunks x object`` result is what ``_inject_kv_into_layer``
+        expects with ``num_chunks=num_chunks`` (the same contract as the
+        sync layerwise load path).
+        """
+        if not layer_infos or num_chunks <= 0:
+            raise ValueError("layerwise layer copy requires at least one chunk")
+        dtype = kv_cache_layer.dtype
+        obj_elems = layer_infos[0].view.nbytes // dtype.itemsize
+        out = torch.empty(
+            num_chunks * obj_elems, dtype=dtype, device=kv_cache_layer.device
+        )
+        for chunk_start, run_chunks, run_view in self._chunk_runs(
+            layer_infos[:num_chunks]
+        ):
+            out[chunk_start * obj_elems : (chunk_start + run_chunks) * obj_elems].copy_(
+                torch.frombuffer(run_view, dtype=dtype), non_blocking=True
+            )
+        return out
 
     def _fail_deferred_load(self, req_meta: MaruReqMeta) -> None:
         """Mark a deferred load as failed so the scheduler recomputes it.

--- a/maru_vllm/connector.py
+++ b/maru_vllm/connector.py
@@ -214,6 +214,37 @@ def _align_down(num_tokens: int, block_size: int) -> int:
     return (num_tokens // block_size) * block_size
 
 
+def _chunk_layer_key(base_key: str, layer_idx: int) -> str:
+    """Key of one (chunk, layer) object under the layerwise storage format.
+
+    The single owner of the ``_L<idx>`` suffix — the store, the sync load,
+    and the off-thread load must all agree on it, or a mismatch presents as
+    a 100%-miss cache (recompute) rather than an error.
+    """
+    return f"{base_key}_L{layer_idx}"
+
+
+def _load_keys(
+    chunk_keys: list[str],
+    num_chunks: int,
+    layers: list[tuple[str, torch.Tensor, int]],
+    use_layerwise: bool,
+) -> list[str]:
+    """Retrieve keys for one request's matched chunks.
+
+    Packed: one key per chunk. Layerwise: one key per (chunk, layer),
+    layer-major in the caller's own layer order — consumers must index the
+    result with that same order (or re-key by true layer index).
+    """
+    if use_layerwise:
+        return [
+            _chunk_layer_key(chunk_keys[ci], layer_idx)
+            for (_, _, layer_idx) in layers
+            for ci in range(num_chunks)
+        ]
+    return [chunk_keys[ci] for ci in range(num_chunks)]
+
+
 def _chunk_keys(token_ids: list[int], chunk_tokens: int) -> list[str]:
     """Generate maru keys for each chunk of the token prefix.
 
@@ -1122,11 +1153,14 @@ class MaruWorkerConnector:
         self._load_admission_window = int(
             extra_config.get("maru_load_admission_window", 0)
         )
-        # Packed layerwise overlap keeps the packed Maru object format. The
-        # loader thread resolves only the RPC/mmap metadata; the resumed
-        # forward consumes these entries layer-by-layer on _load_stream.
+        # Overlap loads whose off-thread copy issue failed: the loader thread
+        # resolved the RPC/mmap metadata and the resumed forward consumes
+        # these entries layer-by-layer on _load_stream. The retained views are
+        # a flat per-chunk list of packed slabs, or (under maru_use_layerwise)
+        # a dict keyed by true layer index.
         self._deferred_layerwise_loads: dict[
-            str, tuple[MaruReqMeta, int, torch.Tensor, list[Any]]
+            str,
+            tuple[MaruReqMeta, int, torch.Tensor, list[Any] | dict[int, list[Any]]],
         ] = {}
         # Per-layer copies queued by the loader thread while the request was
         # parked; the resumed forward waits on these instead of issuing
@@ -1415,14 +1449,7 @@ class MaruWorkerConnector:
 
             # Packed (default): one key per chunk (num_chunks keys). Layerwise:
             # one key per (chunk, layer), layer-major (num_chunks x num_layers).
-            if self._use_layerwise:
-                keys = [
-                    f"{chunk_keys[ci]}_L{layer_idx}"
-                    for (_, _, layer_idx) in layers
-                    for ci in range(num_chunks)
-                ]
-            else:
-                keys = [chunk_keys[ci] for ci in range(num_chunks)]
+            keys = _load_keys(chunk_keys, num_chunks, layers, self._use_layerwise)
             try:
                 _t0 = time.monotonic()
                 infos = self._batch_retrieve_all(keys)
@@ -1434,6 +1461,19 @@ class MaruWorkerConnector:
             except Exception as e:
                 logger.error(
                     "Maru batch_retrieve failed for req %s: %s", req_meta.req_id, e
+                )
+                self._fail_deferred_load(req_meta)
+                continue
+
+            if len(infos) != len(keys):
+                # A truncated response would otherwise shift every later
+                # layer's objects by one position — silent wrong KV.
+                logger.error(
+                    "Maru retrieve returned %d infos for %d keys — "
+                    "recompute for req %s",
+                    len(infos),
+                    len(keys),
+                    req_meta.req_id,
                 )
                 self._fail_deferred_load(req_meta)
                 continue
@@ -1565,22 +1605,23 @@ class MaruWorkerConnector:
             if self._use_layerwise and not req_meta.layerwise_load:
                 # The whole-request branch below only understands packed
                 # slabs; the submit gate never sends this combination, so a
-                # request reaching it means a wiring bug — recompute instead.
+                # request reaching it means a wiring bug — recompute instead,
+                # and say so: silently failing here would present as a
+                # cache-hit-rate drop with no diagnostic.
+                logger.error(
+                    "Maru wiring bug: layerwise-format deferred load for req %s "
+                    "reached the off-thread job without layerwise_load; "
+                    "recomputing",
+                    req_meta.req_id,
+                )
                 self._fail_deferred_load(req_meta)
                 return
             total_tokens = num_chunks * self._kv_chunk_tokens
             slot_mapping = self._build_slot_mapping(req_meta.block_ids, total_tokens)
-            if self._use_layerwise:
-                # One key per (chunk, layer), layer-major, in this job's own
-                # layer order — consumers index the retained dict by true
-                # layer index, never by list position.
-                keys = [
-                    f"{chunk_keys[ci]}_L{layer_idx}"
-                    for (_, _, layer_idx) in layers
-                    for ci in range(num_chunks)
-                ]
-            else:
-                keys = [chunk_keys[ci] for ci in range(num_chunks)]
+            # Layerwise keys come back layer-major in this job's own layer
+            # order — consumers index the retained dict by true layer index,
+            # never by list position.
+            keys = _load_keys(chunk_keys, num_chunks, layers, self._use_layerwise)
 
             _t0 = time.monotonic()
             infos = self._batch_retrieve_all(keys)
@@ -1589,6 +1630,18 @@ class MaruWorkerConnector:
                     f"deferred retrieve batch {len(keys)} keys = "
                     f"{(time.monotonic() - _t0) * 1000:.2f} ms (req {req_meta.req_id})"
                 )
+            if len(infos) != len(keys):
+                # A truncated response would otherwise pass the None scan and
+                # leave staging-buffer tails uninitialized — silent corruption.
+                logger.error(
+                    "Maru deferred retrieve returned %d infos for %d keys — "
+                    "recompute for req %s",
+                    len(infos),
+                    len(keys),
+                    req_meta.req_id,
+                )
+                self._fail_deferred_load(req_meta)
+                return
             miss = next((i for i, v in enumerate(infos) if v is None), -1)
             if miss >= 0:
                 logger.warning(
@@ -1660,7 +1713,7 @@ class MaruWorkerConnector:
                         self._deferred_done.add(req_meta.req_id)
                     return
                 logger.info(
-                    "Maru: deferred retrieve ready for packed-layerwise load "
+                    "Maru: deferred retrieve ready for layerwise-overlap load "
                     "%d chunks (%d tokens) for req %s (%s)",
                     num_chunks,
                     total_tokens,
@@ -1856,7 +1909,7 @@ class MaruWorkerConnector:
         req_meta: MaruReqMeta,
         num_chunks: int,
         slot_mapping: torch.Tensor,
-        infos: list[Any],
+        infos: list[Any] | dict[int, list[Any]],
         layers: list[tuple[str, torch.Tensor, int]],
         device: torch.device,
     ) -> dict[str, torch.cuda.Event] | None:
@@ -1959,7 +2012,9 @@ class MaruWorkerConnector:
         transfer queued in parallel with layer k compute. No device-wide
         synchronize is used.
         """
-        entries: list[tuple[MaruReqMeta, int, torch.Tensor, list[Any]]] = []
+        entries: list[
+            tuple[MaruReqMeta, int, torch.Tensor, list[Any] | dict[int, list[Any]]]
+        ] = []
         missing: list[str] = []
         with self._deferred_lock:
             for req_id in req_ids:
@@ -1970,7 +2025,7 @@ class MaruWorkerConnector:
                     entries.append(entry)
         if missing:
             logger.warning(
-                "Maru packed-layerwise activation missing retained load(s): %s",
+                "Maru layerwise-overlap activation missing retained load(s): %s",
                 ", ".join(sorted(missing)),
             )
         if not entries:
@@ -2068,7 +2123,7 @@ class MaruWorkerConnector:
                     event.record(load_stream)
                     issued[layer_name] = event
         except Exception as e:
-            logger.error("Maru packed-layerwise activation failed: %s", e)
+            logger.error("Maru layerwise-overlap activation failed: %s", e)
             try:
                 load_stream.synchronize()
             except Exception:
@@ -2094,13 +2149,13 @@ class MaruWorkerConnector:
         refs.extend(slot_mappings_gpu)
         self._active_load_refs.append((batch_event, refs))
         logger.info(
-            "Maru: packed-layerwise scheduled %d layers x %d requests on load stream",
+            "Maru: layerwise-overlap scheduled %d layers x %d requests on load stream",
             len(layers),
             len(entries),
         )
         if self._timing:
             _emit_timing(
-                f"packed-layerwise schedule {len(layers)}L x {len(entries)}r = "
+                f"layerwise-overlap schedule {len(layers)}L x {len(entries)}r = "
                 f"{(time.monotonic() - _t0) * 1000:.2f} ms"
             )
 
@@ -2189,8 +2244,15 @@ class MaruWorkerConnector:
         """
         if not layer_infos or num_chunks <= 0:
             raise ValueError("layerwise layer copy requires at least one chunk")
+        if len(layer_infos) < num_chunks:
+            # Writing fewer runs than num_chunks would leave uninitialized
+            # tails in the staging tensor and inject them as KV.
+            raise ValueError(
+                f"layerwise layer copy got {len(layer_infos)} objects "
+                f"for {num_chunks} chunks"
+            )
         dtype = kv_cache_layer.dtype
-        obj_elems = layer_infos[0].view.nbytes // dtype.itemsize
+        obj_elems = layer_infos[0].view.nbytes // kv_cache_layer.element_size()
         out = torch.empty(
             num_chunks * obj_elems, dtype=dtype, device=kv_cache_layer.device
         )
@@ -2487,7 +2549,7 @@ class MaruWorkerConnector:
         whole to LMCache's ``multi_layer_kv_transfer``, which reads the pinned
         CXL host memory directly (UVA) and scatters all layers into the paged
         GPU cache in one kernel per chunk — the same no-staging path LMCache's
-        ``VLLMPagedMemGPUConnectorV2.to_gpu`` uses. This avoids both v1's 1,888
+        ``VLLMPagedMemGPUConnectorV2.to_gpu`` uses. This avoids both v1's ~8,000
         tiny copies and the reverted GPU-staging OOM. Non-Flash layouts, CPU,
         or a missing ``lmcache.c_ops`` fall back to a per-layer inject that
         reads the same slab slices.
@@ -2503,7 +2565,7 @@ class MaruWorkerConnector:
         # Queue all per-chunk transfers on a dedicated high-priority stream and
         # sync once at the end — mirrors LMCache batched_to_gpu (per-chunk
         # multi_layer_kv_transfer on its load_stream, one synchronize). Keeps
-        # the 59 launches pipelined instead of serializing on the compute
+        # the ~250 launches pipelined instead of serializing on the compute
         # stream. Falls back to the current stream on CPU/non-CUDA.
         dev = layers[0][1].device
         use_stream = kernel is not None or (
@@ -2838,7 +2900,7 @@ class MaruWorkerConnector:
             pending_handles: list = []
             for ci in range(start_chunk, end_chunk):
                 base_key = chunk_keys[ci]
-                maru_key = f"{base_key}_L{layer_idx}"
+                maru_key = _chunk_layer_key(base_key, layer_idx)
                 if maru_key in self._stored_keys:
                     continue
 

--- a/tests/unit/test_vllm_connector.py
+++ b/tests/unit/test_vllm_connector.py
@@ -2363,6 +2363,93 @@ class TestLayerwiseFormatOverlap:
         assert worker._deferred_layerwise_loads == {}
         assert worker._deferred_layerwise_events == {}
 
+    def test_offthread_job_truncated_retrieve_recomputes_while_parked(self):
+        """A short batch_retrieve response (fewer infos than keys, no Nones)
+        must fail the load while parked — never inject an uninitialized
+        staging tail as if it were a successful cache hit."""
+        worker = self._layerwise_worker()
+        obj_bytes = 2 * self.CHUNK * 4
+        infos = [
+            SimpleNamespace(
+                view=memoryview(bytearray(obj_bytes)), region_id=0, page_index=i
+            )
+            for i in range(15)  # one short of 8 chunks x 2 layers
+        ]
+        worker._handler.batch_retrieve.return_value = infos
+
+        worker._deferred_packed_load_job(
+            self._deferred_meta(),
+            [("l0", torch.zeros(2, 16, 4, 1), 0), ("l1", torch.zeros(2, 16, 4, 1), 1)],
+            torch.device("cpu"),
+        )
+
+        assert worker.get_finished_loading() == {"r1"}
+        assert worker.take_failed_load_blocks() == set(range(16))
+        assert worker._deferred_layerwise_loads == {}
+        assert worker._deferred_layerwise_events == {}
+
+    def test_sync_path_truncated_retrieve_recomputes(self, caplog):
+        """The synchronous load path rejects a short retrieve response the
+        same way, before any per-layer indexing can misattribute objects."""
+        from maru_vllm.connector import MaruConnectorMetadata
+
+        worker = make_worker(
+            block_size=4,
+            kv_chunk_tokens=4,
+            extra_config={"maru_use_layerwise": True, "maru_async_load": True},
+        )
+        worker._num_layers = 2
+        worker._handler = MagicMock()
+        obj_bytes = 2 * 4 * 4
+        worker._handler.batch_retrieve.return_value = [
+            SimpleNamespace(
+                view=memoryview(bytearray(obj_bytes)), region_id=0, page_index=0
+            )
+        ]  # one short of 1 chunk x 2 layers
+        meta = deferred_req_meta(
+            token_ids=list(range(4)), block_ids=[0], num_matched_chunks=1
+        )
+
+        with caplog.at_level("ERROR"):
+            worker.start_load_kv(
+                self._forward(torch.zeros(2, 1, 4, 1), torch.zeros(2, 1, 4, 1)),
+                MaruConnectorMetadata(requests=[meta]),
+            )
+
+        assert "1 infos for 2 keys" in caplog.text
+        assert worker.get_finished_loading() == {"r1"}
+        assert worker.take_failed_load_blocks() == {0}
+
+    def test_layerwise_gather_rejects_short_layer_infos(self):
+        worker = make_worker(
+            block_size=4, kv_chunk_tokens=4, extra_config=dict(self.CONFIG)
+        )
+        info = SimpleNamespace(
+            view=memoryview(bytearray(2 * 4 * 4)), region_id=0, page_index=0
+        )
+
+        with pytest.raises(ValueError):
+            worker._copy_layerwise_layer_to_device([info], 2, torch.zeros(2, 1, 4, 1))
+
+    def test_mismarked_layerwise_request_logs_an_error(self, caplog):
+        """The defensive guard in the off-thread job must be loud: a request
+        reaching it means a wiring bug, and silently recomputing would look
+        like a cache-hit-rate drop with no diagnostic."""
+        worker = self._layerwise_worker()
+        meta = self._deferred_meta()
+        meta.layerwise_load = False
+
+        with caplog.at_level("ERROR"):
+            worker._deferred_packed_load_job(
+                meta,
+                [("l0", torch.zeros(2, 16, 4, 1), 0)],
+                torch.device("cpu"),
+            )
+
+        assert "layerwise" in caplog.text.lower()
+        assert worker.get_finished_loading() == {"r1"}
+        assert worker.take_failed_load_blocks() == set(range(16))
+
     def test_activation_cpu_fallback_preserves_layerwise_objects(self):
         from maru_vllm.connector import MaruConnectorMetadata
 

--- a/tests/unit/test_vllm_connector.py
+++ b/tests/unit/test_vllm_connector.py
@@ -2194,6 +2194,419 @@ class TestPreIssuedLayerwiseHandoff:
         assert worker.take_failed_load_blocks() == {7, 8}
 
 
+class TestLayerwiseFormatOverlap:
+    """Overlap load-with-compute on the layerwise storage format.
+
+    The overlap machinery originally required the packed layout; these tests
+    pin the extension that lets `maru_use_layerwise=true` deployments keep it.
+    """
+
+    CHUNK = 8
+    CONFIG = {
+        "maru_use_layerwise": True,
+        "maru_async_load": True,
+        "maru_overlap_load_with_compute": True,
+    }
+
+    def test_gates_open_for_layerwise_format(self, caplog):
+        with caplog.at_level("WARNING"):
+            scheduler = make_scheduler(
+                block_size=4, kv_chunk_tokens=self.CHUNK, extra_config=dict(self.CONFIG)
+            )
+            worker = make_worker(
+                block_size=4, kv_chunk_tokens=self.CHUNK, extra_config=dict(self.CONFIG)
+            )
+
+        assert scheduler._layerwise_overlap is True
+        assert worker._layerwise_overlap is True
+        assert "disabling" not in caplog.text
+
+    def test_overlap_still_requires_async_load(self, caplog):
+        config = {"maru_use_layerwise": True, "maru_overlap_load_with_compute": True}
+        with caplog.at_level("WARNING"):
+            scheduler = make_scheduler(
+                block_size=4, kv_chunk_tokens=self.CHUNK, extra_config=dict(config)
+            )
+            worker = make_worker(
+                block_size=4, kv_chunk_tokens=self.CHUNK, extra_config=dict(config)
+            )
+
+        assert scheduler._layerwise_overlap is False
+        assert worker._layerwise_overlap is False
+        assert "disabling" in caplog.text
+
+    def test_layerwise_gather_coalesces_runs_and_keeps_gapped_pages(self):
+        """Consecutive per-(chunk,layer) pages combine into one copy; a
+        gapped page is copied alone; output is chunk-ordered and flat."""
+        worker = make_worker(
+            block_size=4, kv_chunk_tokens=4, extra_config=dict(self.CONFIG)
+        )
+        kv_cache_layer = torch.zeros(2, 1, 4, 1)  # dtype/device donor
+        obj_elems = 2 * 4 * 1  # K/V x tokens x hidden
+        obj_bytes = obj_elems * 4
+        worker._effective_page_size_bytes = obj_bytes
+        src = torch.arange(3 * obj_elems, dtype=torch.float32)
+        region = bytearray(src[: 2 * obj_elems].numpy().tobytes())
+        infos = [
+            SimpleNamespace(
+                view=memoryview(region)[i * obj_bytes : (i + 1) * obj_bytes],
+                region_id=0,
+                page_index=i,
+            )
+            for i in range(2)
+        ]
+        infos.append(
+            SimpleNamespace(
+                view=memoryview(bytearray(src[2 * obj_elems :].numpy().tobytes())),
+                region_id=1,
+                page_index=7,
+            )
+        )
+
+        out = worker._copy_layerwise_layer_to_device(infos, 3, kv_cache_layer)
+
+        assert out.shape == (3 * obj_elems,)
+        torch.testing.assert_close(out, src)
+
+    def test_scheduler_marks_layerwise_load_on_deferred_meta(self):
+        sched = make_scheduler(
+            block_size=4, kv_chunk_tokens=self.CHUNK, extra_config=dict(self.CONFIG)
+        )
+        sched._handler = MagicMock()
+        request = SimpleNamespace(request_id="r1", prompt_token_ids=list(range(64)))
+        sched._last_match_result[request.request_id] = 8
+        blocks = MagicMock()
+        blocks.get_block_ids.return_value = ([3, 4, 5],)
+        sched.update_state_after_alloc(request, blocks, 64)
+
+        meta = sched.build_connector_meta(fake_scheduler_output())
+        assert meta.requests[0].deferred_load
+        assert meta.requests[0].layerwise_load
+
+    def _layerwise_worker(self, num_layers=2):
+        worker = make_worker(
+            block_size=4, kv_chunk_tokens=self.CHUNK, extra_config=dict(self.CONFIG)
+        )
+        worker._handler = MagicMock()
+        worker._num_layers = num_layers
+        return worker
+
+    def _deferred_meta(self):
+        meta = deferred_req_meta(
+            token_ids=list(range(64)),
+            block_ids=list(range(16)),
+            num_matched_chunks=8,
+        )
+        meta.layerwise_load = True
+        return meta
+
+    def test_offthread_job_retrieves_layer_major_keys(self):
+        """The loader thread resolves every (chunk, layer) key before any
+        release gate can exist, and retains them keyed by true layer index."""
+        from maru_vllm.connector import _chunk_keys
+
+        worker = self._layerwise_worker()
+        obj_bytes = 2 * self.CHUNK * 4
+        infos = [
+            SimpleNamespace(
+                view=memoryview(bytearray([i + 1] * obj_bytes)),
+                region_id=0,
+                page_index=i,
+            )
+            for i in range(16)  # 8 chunks x 2 layers
+        ]
+        worker._handler.batch_retrieve.return_value = infos
+        meta = self._deferred_meta()
+
+        worker._deferred_packed_load_job(
+            meta,
+            [("l0", torch.zeros(2, 16, 4, 1), 0), ("l1", torch.zeros(2, 16, 4, 1), 1)],
+            torch.device("cpu"),
+        )
+
+        chunk_keys = _chunk_keys(meta.token_ids, self.CHUNK)
+        expected_keys = [f"{ck}_L0" for ck in chunk_keys] + [
+            f"{ck}_L1" for ck in chunk_keys
+        ]
+        worker._handler.batch_retrieve.assert_called_once_with(expected_keys)
+        # CPU makes the off-thread issue fail, so the job retains the views
+        # for the resumed forward — keyed by true layer index.
+        retained = worker._deferred_layerwise_loads["r1"]
+        assert retained[3] == {0: infos[:8], 1: infos[8:]}
+        assert worker.get_finished_loading() == {"r1"}
+
+    def test_offthread_job_miss_recomputes_while_parked(self):
+        """Any missing (chunk, layer) object fails the whole load before the
+        request is released — vLLM recomputes instead of consuming holes."""
+        worker = self._layerwise_worker()
+        obj_bytes = 2 * self.CHUNK * 4
+        infos: list = [
+            SimpleNamespace(
+                view=memoryview(bytearray(obj_bytes)), region_id=0, page_index=i
+            )
+            for i in range(16)
+        ]
+        infos[12] = None  # one (chunk, layer) object of the last layer evicted
+        worker._handler.batch_retrieve.return_value = infos
+
+        worker._deferred_packed_load_job(
+            self._deferred_meta(),
+            [("l0", torch.zeros(2, 16, 4, 1), 0), ("l1", torch.zeros(2, 16, 4, 1), 1)],
+            torch.device("cpu"),
+        )
+
+        # The failed lookup really covered every (chunk, layer) key.
+        (retrieved_keys,) = worker._handler.batch_retrieve.call_args.args
+        assert len(retrieved_keys) == 16
+        assert worker.get_finished_loading() == {"r1"}
+        assert worker.take_failed_load_blocks() == set(range(16))
+        assert worker._deferred_layerwise_loads == {}
+        assert worker._deferred_layerwise_events == {}
+
+    def test_activation_cpu_fallback_preserves_layerwise_objects(self):
+        from maru_vllm.connector import MaruConnectorMetadata
+
+        worker = make_worker(
+            block_size=4, kv_chunk_tokens=4, extra_config=dict(self.CONFIG)
+        )
+        worker._handler = MagicMock()
+        worker._num_layers = 2
+        sources = [
+            torch.arange(2 * 4, dtype=torch.float32).view(2, 4, 1) + 100 * li
+            for li in range(2)
+        ]
+        payload = {
+            li: [
+                SimpleNamespace(
+                    view=memoryview(bytearray(src.numpy().tobytes())),
+                    region_id=li,
+                    page_index=0,
+                )
+            ]
+            for li, src in enumerate(sources)
+        }
+        meta = self._deferred_meta()
+        meta.num_matched_chunks = 1
+        meta.block_ids = [0]
+        worker._deferred_layerwise_loads["r1"] = (meta, 1, torch.arange(4), payload)
+        kv0 = torch.zeros(2, 1, 4, 1)
+        kv1 = torch.zeros_like(kv0)
+        forward = SimpleNamespace(
+            no_compile_layers={
+                "model.layers.0.self_attn": SimpleNamespace(kv_cache=kv0),
+                "model.layers.1.self_attn": SimpleNamespace(kv_cache=kv1),
+            },
+            attn_metadata=None,
+        )
+
+        worker.start_load_kv(
+            forward,
+            MaruConnectorMetadata(layerwise_load_req_ids={"r1"}),
+        )
+
+        torch.testing.assert_close(kv0, sources[0].view_as(kv0))
+        torch.testing.assert_close(kv1, sources[1].view_as(kv1))
+        assert worker._deferred_layerwise_loads == {}
+        assert worker._layer_load_events == {}
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    def test_activation_records_one_event_per_layer_for_layerwise_objects(self):
+        from maru_vllm.connector import MaruConnectorMetadata
+
+        worker = make_worker(
+            block_size=4, kv_chunk_tokens=4, extra_config=dict(self.CONFIG)
+        )
+        worker._handler = MagicMock()
+        worker._num_layers = 2
+        # Per layer: 2 chunks, each object [2(KV), 4 tokens, 1 hidden], laid
+        # out consecutively in one region so _chunk_runs coalesces them.
+        sources = [
+            torch.arange(2 * 2 * 4, dtype=torch.float32).view(2, 2, 4, 1) + 100 * li
+            for li in range(2)
+        ]
+        obj_bytes = sources[0][0].numel() * sources[0].element_size()
+        worker._effective_page_size_bytes = obj_bytes
+        payload = {}
+        for li, src in enumerate(sources):
+            region = bytearray(src.numpy().tobytes())
+            payload[li] = [
+                SimpleNamespace(
+                    view=memoryview(region)[ci * obj_bytes : (ci + 1) * obj_bytes],
+                    region_id=li,
+                    page_index=ci,
+                )
+                for ci in range(2)
+            ]
+        meta = self._deferred_meta()
+        meta.num_matched_chunks = 2
+        meta.block_ids = [0, 1]
+        worker._deferred_layerwise_loads["r1"] = (meta, 2, torch.arange(8), payload)
+        kv0 = torch.zeros(2, 2, 4, 1, device="cuda")
+        kv1 = torch.zeros_like(kv0)
+        forward = SimpleNamespace(
+            no_compile_layers={
+                "model.layers.0.self_attn": SimpleNamespace(kv_cache=kv0),
+                "model.layers.1.self_attn": SimpleNamespace(kv_cache=kv1),
+            },
+            attn_metadata=None,
+        )
+
+        worker.start_load_kv(
+            forward,
+            MaruConnectorMetadata(layerwise_load_req_ids={"r1"}),
+        )
+
+        assert set(worker._layer_load_events) == {
+            "model.layers.0.self_attn",
+            "model.layers.1.self_attn",
+        }
+        worker.wait_for_layer_load("model.layers.0.self_attn")
+        worker.wait_for_layer_load("model.layers.1.self_attn")
+        torch.cuda.synchronize()
+        torch.testing.assert_close(kv0.cpu(), sources[0].permute(1, 0, 2, 3))
+        torch.testing.assert_close(kv1.cpu(), sources[1].permute(1, 0, 2, 3))
+
+    def _forward(self, kv0, kv1):
+        return SimpleNamespace(
+            no_compile_layers={
+                "model.layers.0.self_attn": SimpleNamespace(kv_cache=kv0),
+                "model.layers.1.self_attn": SimpleNamespace(kv_cache=kv1),
+            },
+            attn_metadata=make_flash_attn_metadata(),
+        )
+
+    def test_start_load_kv_submits_layerwise_overlap_offthread(self, monkeypatch):
+        from maru_vllm.connector import MaruConnectorMetadata
+
+        worker = self._layerwise_worker()
+        submitted: list[str] = []
+        monkeypatch.setattr(
+            worker,
+            "_try_submit_deferred_packed_load",
+            lambda req_meta: submitted.append(req_meta.req_id) or True,
+        )
+        meta = self._deferred_meta()
+
+        worker.start_load_kv(
+            self._forward(torch.zeros(2, 16, 4, 1), torch.zeros(2, 16, 4, 1)),
+            MaruConnectorMetadata(requests=[meta]),
+        )
+
+        assert submitted == ["r1"]
+        worker._handler.batch_retrieve.assert_not_called()
+
+    def test_overlap_off_layerwise_keeps_the_sync_path(self, monkeypatch):
+        from maru_vllm.connector import MaruConnectorMetadata, _chunk_keys
+
+        worker = make_worker(
+            block_size=4,
+            kv_chunk_tokens=4,
+            extra_config={"maru_use_layerwise": True, "maru_async_load": True},
+        )
+        worker._num_layers = 2
+        submitted: list[str] = []
+        monkeypatch.setattr(
+            worker,
+            "_try_submit_deferred_packed_load",
+            lambda req_meta: submitted.append(req_meta.req_id) or True,
+        )
+        sources = [
+            torch.arange(2 * 4, dtype=torch.float32).view(2, 4, 1) + 100 * li
+            for li in range(2)
+        ]
+        worker._handler = MagicMock()
+        worker._handler.batch_retrieve.return_value = [
+            SimpleNamespace(
+                view=memoryview(bytearray(src.numpy().tobytes())),
+                region_id=li,
+                page_index=0,
+            )
+            for li, src in enumerate(sources)
+        ]
+        meta = deferred_req_meta(
+            token_ids=list(range(4)), block_ids=[0], num_matched_chunks=1
+        )
+        assert meta.layerwise_load is False  # overlap off: scheduler never marks
+        kv0 = torch.zeros(2, 1, 4, 1)
+        kv1 = torch.zeros_like(kv0)
+
+        worker.start_load_kv(
+            self._forward(kv0, kv1), MaruConnectorMetadata(requests=[meta])
+        )
+
+        assert submitted == []
+        (retrieved_keys,) = worker._handler.batch_retrieve.call_args.args
+        base = _chunk_keys(meta.token_ids, 4)[0]
+        assert retrieved_keys == [f"{base}_L0", f"{base}_L1"]
+        assert worker.get_finished_loading() == {"r1"}
+        torch.testing.assert_close(kv0, sources[0].view_as(kv0))
+        torch.testing.assert_close(kv1, sources[1].view_as(kv1))
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    def test_offthread_overlap_end_to_end_on_cuda(self):
+        """Loader thread queues per-layer copies from layerwise objects, the
+        gate unparks the request, and the resumed forward waits per layer."""
+        import time as _time
+
+        from maru_vllm.connector import MaruConnectorMetadata
+
+        worker = make_worker(
+            block_size=4, kv_chunk_tokens=4, extra_config=dict(self.CONFIG)
+        )
+        kv0 = torch.zeros(2, 2, 4, 1, device="cuda")
+        kv1 = torch.zeros_like(kv0)
+        worker._kv_caches = {
+            "model.layers.0.self_attn": kv0,
+            "model.layers.1.self_attn": kv1,
+        }
+        worker._num_layers = 2
+        sources = [
+            torch.arange(2 * 2 * 4, dtype=torch.float32).view(2, 2, 4, 1) + 100 * li
+            for li in range(2)
+        ]
+        obj_bytes = sources[0][0].numel() * sources[0].element_size()
+        infos = []
+        for src in sources:  # layer-major, matching the job's key order
+            region = bytearray(src.numpy().tobytes())
+            infos.extend(
+                SimpleNamespace(
+                    view=memoryview(region)[ci * obj_bytes : (ci + 1) * obj_bytes],
+                    region_id=0,
+                    page_index=ci,
+                )
+                for ci in range(2)
+            )
+        worker._handler = MagicMock()
+        worker._handler.batch_retrieve.return_value = infos
+        meta = deferred_req_meta(
+            token_ids=list(range(8)), block_ids=[0, 1], num_matched_chunks=2
+        )
+        meta.layerwise_load = True
+
+        worker.start_load_kv(
+            self._forward(kv0, kv1), MaruConnectorMetadata(requests=[meta])
+        )
+
+        deadline = _time.monotonic() + 5.0
+        finished: set = set()
+        while _time.monotonic() < deadline and not finished:
+            finished = worker.get_finished_loading() or set()
+            _time.sleep(0.01)
+        assert finished == {"r1"}
+        # The copies were queued off-thread; the resumed forward only
+        # installs their events and waits per layer.
+        worker.start_load_kv(
+            self._forward(kv0, kv1),
+            MaruConnectorMetadata(layerwise_load_req_ids={"r1"}),
+        )
+        assert set(worker._layer_load_events) == set(worker._kv_caches)
+        for name in worker._kv_caches:
+            worker.wait_for_layer_load(name)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(kv0.cpu(), sources[0].permute(1, 0, 2, 3))
+        torch.testing.assert_close(kv1.cpu(), sources[1].permute(1, 0, 2, 3))
+
+
 class _FakeAdmissionEvent:
     """Stand-in CUDA event: query() flips true after synchronize()."""
 

--- a/tests/unit/test_vllm_connector.py
+++ b/tests/unit/test_vllm_connector.py
@@ -2197,8 +2197,9 @@ class TestPreIssuedLayerwiseHandoff:
 class TestLayerwiseFormatOverlap:
     """Overlap load-with-compute on the layerwise storage format.
 
-    The overlap machinery originally required the packed layout; these tests
-    pin the extension that lets `maru_use_layerwise=true` deployments keep it.
+    The overlap machinery originally required the chunkwise layout; these
+    tests pin the extension that lets `maru_use_layerwise=true` deployments
+    keep it.
     """
 
     CHUNK = 8

--- a/tests/unit/test_vllm_connector.py
+++ b/tests/unit/test_vllm_connector.py
@@ -1438,7 +1438,7 @@ class TestDeferredLoading:
         sched.update_state_after_alloc(self._request(), MagicMock(), 0)
         assert sched._pending_deferred_loads == {}
 
-    def test_second_alloc_activates_packed_layerwise_load_once(self):
+    def test_second_alloc_activates_layerwise_load_once(self):
         sched = self._make_scheduler(layerwise_overlap=True)
         request = self._request()
         sched._last_match_result[request.request_id] = 8
@@ -1644,13 +1644,13 @@ class TestAsyncDeferredPackedLoad:
 
     def test_submit_refused_without_registered_caches(self):
         worker = self._make_worker()
-        assert worker._try_submit_deferred_packed_load(self._deferred_meta()) is False
+        assert worker._try_submit_deferred_load(self._deferred_meta()) is False
 
     def test_submit_refused_on_cpu_caches(self):
         worker = self._make_worker()
         worker._kv_caches = {"l0": torch.zeros(2, 16, 4, 1)}
         worker._num_layers = 1
-        assert worker._try_submit_deferred_packed_load(self._deferred_meta()) is False
+        assert worker._try_submit_deferred_load(self._deferred_meta()) is False
 
     def test_layerwise_mode_background_job_stops_after_retrieve(self):
         worker = make_worker(
@@ -1676,7 +1676,7 @@ class TestAsyncDeferredPackedLoad:
         meta = self._deferred_meta()
         meta.layerwise_load = True
 
-        worker._deferred_packed_load_job(
+        worker._deferred_load_job(
             meta,
             [("l0", torch.zeros(2, 16, 4, 1), 0)],
             torch.device("cpu"),
@@ -1688,7 +1688,7 @@ class TestAsyncDeferredPackedLoad:
         assert retained[3] == infos
         assert worker._deferred_events == {}
 
-    def test_layerwise_activation_cpu_fallback_preserves_packed_layout(self):
+    def test_layerwise_activation_cpu_fallback_preserves_chunkwise_layout(self):
         from maru_vllm.connector import MaruConnectorMetadata
 
         worker = make_worker(
@@ -1834,7 +1834,7 @@ class TestAsyncDeferredPackedLoad:
         worker._handler = MagicMock()
         worker._handler.batch_retrieve.return_value = infos
 
-        assert worker._try_submit_deferred_packed_load(self._deferred_meta()) is True
+        assert worker._try_submit_deferred_load(self._deferred_meta()) is True
         assert self._poll_finished(worker) == {"r1"}
         assert worker.take_failed_load_blocks() == set()
         torch.cuda.synchronize()
@@ -1859,7 +1859,7 @@ class TestAsyncDeferredPackedLoad:
         worker._handler.batch_retrieve.return_value = infos
         meta = self._deferred_meta()
 
-        worker._deferred_packed_load_job(
+        worker._deferred_load_job(
             meta,
             [("l0", kv, 0)],
             kv.device,
@@ -1881,7 +1881,7 @@ class TestAsyncDeferredPackedLoad:
         worker._handler = MagicMock()
         worker._handler.batch_retrieve.side_effect = RuntimeError("rpc down")
 
-        assert worker._try_submit_deferred_packed_load(self._deferred_meta()) is True
+        assert worker._try_submit_deferred_load(self._deferred_meta()) is True
         assert self._poll_finished(worker) == {"r1"}
         assert worker.take_failed_load_blocks() == set(range(16))
 
@@ -1893,7 +1893,7 @@ class TestAsyncDeferredPackedLoad:
         worker._handler = MagicMock()
         worker._handler.batch_retrieve.return_value = [None] * 8
 
-        assert worker._try_submit_deferred_packed_load(self._deferred_meta()) is True
+        assert worker._try_submit_deferred_load(self._deferred_meta()) is True
         assert self._poll_finished(worker) == {"r1"}
         assert worker.take_failed_load_blocks() == set(range(16))
 
@@ -1939,7 +1939,7 @@ class TestPreIssuedLayerwiseHandoff:
         reissued: list[set[str]] = []
         monkeypatch.setattr(
             worker,
-            "_schedule_deferred_packed_layerwise_loads",
+            "_schedule_deferred_layerwise_loads",
             lambda layers, req_ids, attn: reissued.append(set(req_ids)),
         )
 
@@ -1965,7 +1965,7 @@ class TestPreIssuedLayerwiseHandoff:
         reissued: list[set[str]] = []
         monkeypatch.setattr(
             worker,
-            "_schedule_deferred_packed_layerwise_loads",
+            "_schedule_deferred_layerwise_loads",
             lambda layers, req_ids, attn: reissued.append(set(req_ids)),
         )
 
@@ -2077,7 +2077,7 @@ class TestPreIssuedLayerwiseHandoff:
             lambda *args, **kwargs: events,
         )
 
-        worker._deferred_packed_load_job(meta, [], torch.device("cpu"))
+        worker._deferred_load_job(meta, [], torch.device("cpu"))
 
         # Copies finished before the report that frees the blocks.
         for event in events.values():
@@ -2117,7 +2117,7 @@ class TestPreIssuedLayerwiseHandoff:
             worker, "_issue_layerwise_copies_offthread", issue_then_abort
         )
 
-        worker._deferred_packed_load_job(meta, [], torch.device("cpu"))
+        worker._deferred_load_job(meta, [], torch.device("cpu"))
 
         for event in events.values():
             event.synchronize.assert_called_once_with()
@@ -2169,7 +2169,7 @@ class TestPreIssuedLayerwiseHandoff:
         )
         monkeypatch.setattr(
             worker,
-            "_copy_packed_layer_to_device",
+            "_copy_chunkwise_layer_to_device",
             MagicMock(side_effect=RuntimeError("copy failed")),
         )
         kv = [torch.zeros(2, 2, 4, 1, device="cuda") for _ in self.LAYERS]
@@ -2319,7 +2319,7 @@ class TestLayerwiseFormatOverlap:
         worker._handler.batch_retrieve.return_value = infos
         meta = self._deferred_meta()
 
-        worker._deferred_packed_load_job(
+        worker._deferred_load_job(
             meta,
             [("l0", torch.zeros(2, 16, 4, 1), 0), ("l1", torch.zeros(2, 16, 4, 1), 1)],
             torch.device("cpu"),
@@ -2350,7 +2350,7 @@ class TestLayerwiseFormatOverlap:
         infos[12] = None  # one (chunk, layer) object of the last layer evicted
         worker._handler.batch_retrieve.return_value = infos
 
-        worker._deferred_packed_load_job(
+        worker._deferred_load_job(
             self._deferred_meta(),
             [("l0", torch.zeros(2, 16, 4, 1), 0), ("l1", torch.zeros(2, 16, 4, 1), 1)],
             torch.device("cpu"),
@@ -2378,7 +2378,7 @@ class TestLayerwiseFormatOverlap:
         ]
         worker._handler.batch_retrieve.return_value = infos
 
-        worker._deferred_packed_load_job(
+        worker._deferred_load_job(
             self._deferred_meta(),
             [("l0", torch.zeros(2, 16, 4, 1), 0), ("l1", torch.zeros(2, 16, 4, 1), 1)],
             torch.device("cpu"),
@@ -2441,7 +2441,7 @@ class TestLayerwiseFormatOverlap:
         meta.layerwise_load = False
 
         with caplog.at_level("ERROR"):
-            worker._deferred_packed_load_job(
+            worker._deferred_load_job(
                 meta,
                 [("l0", torch.zeros(2, 16, 4, 1), 0)],
                 torch.device("cpu"),
@@ -2570,7 +2570,7 @@ class TestLayerwiseFormatOverlap:
         submitted: list[str] = []
         monkeypatch.setattr(
             worker,
-            "_try_submit_deferred_packed_load",
+            "_try_submit_deferred_load",
             lambda req_meta: submitted.append(req_meta.req_id) or True,
         )
         meta = self._deferred_meta()
@@ -2595,7 +2595,7 @@ class TestLayerwiseFormatOverlap:
         submitted: list[str] = []
         monkeypatch.setattr(
             worker,
-            "_try_submit_deferred_packed_load",
+            "_try_submit_deferred_load",
             lambda req_meta: submitted.append(req_meta.req_id) or True,
         )
         sources = [


### PR DESCRIPTION
## 🤔 Background & Motivation (Why)

`maru_overlap_load_with_compute` hides most of a cache hit behind the request's own prefill: the per-layer copies are queued while the request waits, and the request starts as soon as layer 0 lands, so the rest of the layers arrive while earlier ones are already computing.

This only worked with the chunkwise storage format. Under `maru_use_layerwise=true` the connector turned the overlap off with a warning, and a layerwise cache hit did its key lookup on the engine thread, inside the forward pass.

The two knobs are meant to be independent — `maru_use_layerwise` picks how KV is grouped into CXL objects, `maru_overlap_load_with_compute` picks how a load is pipelined. This PR makes them independent:

| config | before | after |
|---|---|---|
| chunkwise + async_load + overlap | overlap works | unchanged |
| layerwise + async_load + overlap | warned, turned off | **overlap works** |
| layerwise + async_load (overlap off) | lookup on the engine thread | unchanged |

## 🏗️ Design Changes

**Behavioral: either storage format can use the overlap.** A layerwise cache hit now does its key lookup on the loader thread instead of the engine thread, so it no longer blocks the forward pass.

**Behavioral: a lookup that returns fewer objects than keys is now rejected.** The batch lookup answers one entry per key, in order, with a miss marked empty — and the old check only scanned for those empty slots. A reply that was simply shorter than the key list passed it, and because the results are then sliced by position, every layer after the gap read the previous layer's objects, while the tail of the GPU staging buffer was never written and reached the model as uninitialized KV. Both were silent. Every load path now compares the two counts first, logs a mismatch, and recomputes the request.

**Dependency: layerwise no longer touches LMCache.** A chunkwise object holds every layer of a chunk, so reading one layer means slicing it out of each object — that is what the borrowed LMCache kernel is for. A layerwise object is already one layer, stored end to end, so ordinary copies plus PyTorch's scatter are enough. Layerwise deployments therefore do not depend on the installed LMCache version at all.

**Structural: retrieved objects are keyed by layer index.** The loader thread and the resumed forward walk the layers in orders that need not match, so what the loader keeps for the forward is a map from layer index to that layer's objects, not a positional list.

## 📝 Implementation Details

- **Nothing after the load changed, and overlap-off is untouched.** The release gate, the per-layer events the forward waits on, and the preemption/abort cleanup do not care which format was used and run unchanged. A layerwise request goes to the loader thread only when the scheduler marks it for overlap, so deployments running with the overlap off behave exactly as before.

## ✅ Tests

- [x] Unit tests — 15 new: the gates, key building, "a miss, or a reply short of the key count, fails while the request waits", CPU fallback round trip, per-layer CUDA events, an overlap-off regression, and a CUDA end-to-end (background load → release → per-layer waits, bit-exact KV). Whole suite: 913 passed on a 2-GPU node, ruff clean.
- [x] Manual tests — real node, one config run with the overlap off and on (naru `cfg/p2p/long_doc_singlenode_maru_direct_layerwise_overlap.yaml`):

  | | |
  |---|---|
  | Model | Llama-3.1-8B-Instruct, 2 instances on one node (1 GPU each) |
  | Workload | long-doc QA, 16 docs x 32k tokens, 50 output tokens, 2 rounds |
  | Sharing | cross-instance p2p — inst1 stores, inst2 queries (100% hit) |
  | In flight | 1 and 8 |

  `kv_connector_extra_config` — the two arms differ only in the last line:

  ```
  maru_use_layerwise               true
  maru_async_load                  true
  maru_async_store                 false
  maru_load_admission_window       0
  maru_kv_chunk_tokens             256
  maru_overlap_load_with_compute   false  →  true
  ```

  Overlap off → on, on the querying instance. These are cache-hit requests — the overlap only acts on a load, so a miss looks the same either way. vLLM's own prefix cache is off, so the same prompts computed cold took 2,617 ms (1 in flight) and 8,657 ms (8 in flight) to first token.

  | metric | 1 in flight | 8 in flight |
  |---|---|---|
  | TTFT, mean over requests | 306 → **273 ms (−11%)** | 1,086 → **528 ms (−51%)** |
  | TPOT, mean over requests | 14.0 → 14.0 ms | 37.7 → 36.6 ms |
  | Output throughput, run total | 50 → 52 tok/s | 132 → **166 tok/s (+26%)** |

  - Correctness: 192/192 requests succeeded on both arms, with no failed loads or recomputes. Checked separately with greedy decoding on maru's `examples/vllm/p2p_sharing` — a request answered from a layerwise-overlap cache hit produced byte-identical text to the same prompt computed from scratch, and the logs confirm it went through the new path rather than falling back.
  - The chunkwise arm could not run: upstream LMCache moved its KV-format enums (#4453/#4473), which kills the chunkwise store's kernel setup. That is an existing bug this PR does not touch (plain main hits it too) and #72 fixes it. Layerwise is unaffected — it never calls LMCache.

## 📦 Release Note (for auto-generation / write in English)
### NEW
- maru_vllm: `maru_overlap_load_with_compute` now works with the layerwise storage format (`maru_use_layerwise=true`); it only needs `maru_async_load=true`.
### CHANGED
- maru_vllm: overlap log lines now say "layerwise-overlap" instead of "packed-layerwise".
### FIXED
- maru_vllm: a `batch_retrieve` reply shorter than the key list is rejected and recomputed instead of loading uninitialized or layer-shifted KV.
### IMPORTANT NOTES
- With the layerwise format, every (chunk, layer) key is looked up before a waiting request is released, and one loader thread does that work request by request. At 32k prompts with 8 requests in flight it costs ~27 ms each while TTFT still improves 46-51%; measure again before running at much higher concurrency or with longer prompts.









