### PR TITLE
build: adopt uv for install, CI, and docs

### DIFF
--- a/.github/workflows/docs-sphinx.yml
+++ b/.github/workflows/docs-sphinx.yml
@@ -31,8 +31,13 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
       - name: Install dependencies
-        run: pip install -e ".[docs]"
+        run: uv pip install --system -e ".[docs]"
 
       - name: Build docs
         run: sphinx-build -b html docs/ docs/_build/html

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,12 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.12"
-      - name: Install ruff
-        run: pip install ruff
+          enable-cache: true
+
+      # Pinned to the same version as .pre-commit-config.yaml so CI and local
+      # pre-commit agree. Bump both together.
       - name: Run ruff check
-        run: ruff check .
+        run: uvx ruff@0.16.5 check .
+
       - name: Run ruff format check
-        run: ruff format --check .
+        run: uvx ruff@0.16.5 format --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
       - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
-          pip install -e .
+        run: uv pip install --system -e ".[dev]"
       - name: Run unit tests with coverage
         run: |
           pytest -m "not integration" \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.16.5
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -88,12 +88,16 @@ All components run on the same machine in a single-node setup. For multi-node de
 - OS: Ubuntu 24.04 LTS+
 - Python: 3.12+
 - gcc: 13.3.0+, cmake: 3.28.3+
+- [uv](https://docs.astral.sh/uv/) (recommended; `install.sh` falls back to pip)
 - CXL DAX device (`/dev/dax*`) or emulation environment
 
 ```bash
 sudo apt-get update
 sudo apt-get install -y python3 python3-venv python3-pip git \
     build-essential cmake libnuma-dev
+
+# uv — used for all Python installs below
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 ### Installation
@@ -102,7 +106,7 @@ sudo apt-get install -y python3 python3-venv python3-pip git \
 git clone https://github.com/xcena-dev/maru
 cd maru
 
-python3 -m venv .venv
+uv venv --python 3.12 .venv
 source .venv/bin/activate
 ./install.sh
 ```

--- a/docs/source/getting_started/examples/lmcache/p2p.md
+++ b/docs/source/getting_started/examples/lmcache/p2p.md
@@ -9,7 +9,7 @@ When multiple vLLM instances serve the same or similar prompts, they redundantly
 ## Prerequisites
 
 - At least **2 GPUs**
-- [LMCache](https://github.com/LMCache/LMCache) **>= v0.3.14** installed (`pip install lmcache`)
+- [LMCache](https://github.com/LMCache/LMCache) **>= v0.3.14** installed (`uv pip install lmcache`)
 - [vLLM](https://docs.vllm.ai/) installed
 - Maru installed (see {doc}`../../installation`)
 

--- a/docs/source/getting_started/examples/lmcache/pd.md
+++ b/docs/source/getting_started/examples/lmcache/pd.md
@@ -9,7 +9,7 @@ Disaggregated prefill separates the compute-intensive **prefill** phase from the
 ## Prerequisites
 
 - At least **2 GPUs**
-- [LMCache](https://github.com/LMCache/LMCache) **>= v0.3.14** installed (`pip install lmcache`)
+- [LMCache](https://github.com/LMCache/LMCache) **>= v0.3.14** installed (`uv pip install lmcache`)
 - [vLLM](https://docs.vllm.ai/) installed
 - Maru installed (see {doc}`../../installation`)
 

--- a/docs/source/getting_started/examples/vllm/index.md
+++ b/docs/source/getting_started/examples/vllm/index.md
@@ -15,7 +15,7 @@ store and load paths before any cross-instance behavior is involved.
 ## Prerequisites
 
 - 1 GPU for the single-instance example, 2+ for P2P
-- Maru installed: `pip install -e /path/to/maru`
+- Maru installed: `uv pip install -e /path/to/maru`
 - vLLM v0.14+ installed
 - `maru-server` binary available
 

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -21,6 +21,7 @@ In a single-node setup, all components run on the same machine. In a multi-node 
 - gcc: 13.3.0+
 - cmake: 3.28.3+
 - git
+- [uv](https://docs.astral.sh/uv/) — recommended Python package installer
 - CXL DAX device (`/dev/dax*`) or emulation environment
   - **Multi-node:** All participating nodes must be connected to a shared CXL memory pool (e.g., via CXL switch).
 
@@ -28,7 +29,12 @@ In a single-node setup, all components run on the same machine. In a multi-node 
 sudo apt-get update
 sudo apt-get install -y python3 python3-venv python3-pip git \
     build-essential cmake libnuma-dev
+
+# uv — used for all Python installs in this guide
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
+
+> **Note:** `install.sh` uses `uv` when available and falls back to `pip` otherwise, so uv is recommended but not required.
 
 <br/>
 
@@ -46,9 +52,13 @@ git clone https://github.com/xcena-dev/maru
 (Optional) Create a virtual environment and activate it:
 
 ```bash
-python3 -m venv .venv
+uv venv --python 3.12 .venv
 source .venv/bin/activate
 ```
+
+> Pass `--python 3.12` explicitly so the interpreter matches the one your LLM
+> engine (vLLM, SGLang) was built against. Without it, uv may pick any
+> interpreter satisfying `requires-python >= 3.12`.
 
 Install all components (Python package + Resource Manager):
 
@@ -63,6 +73,46 @@ To install **without the Resource Manager** (e.g., on nodes that only run LLM in
 ```
 
 > **Note:** Client nodes still require CXL device access (`/dev/dax*`) for direct mmap. The `--no-rm` flag skips building the Resource Manager binary — the `maru` Python package (including MaruHandler) is still installed and will connect to the remote Resource Manager.
+
+<br/>
+
+### 1.3 Development Install
+
+To work on Maru itself, install the `dev` extra (pytest, mypy, ruff, pre-commit) instead of running `install.sh`:
+
+```bash
+uv venv --python 3.12 .venv
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+```
+
+Without uv, the same install works through pip:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+Install the git hooks once, so lint and format run on every commit:
+
+```bash
+pre-commit install
+```
+
+Then run the unit tests (these need neither a CXL device nor a running service):
+
+```bash
+pytest -m "not integration" --ignore=tests/sglang
+```
+
+To reproduce the lint job exactly, run the hooks against the whole tree. This
+uses the ruff version pinned in `.pre-commit-config.yaml` — the same version CI
+runs:
+
+```bash
+pre-commit run --all-files
+```
 
 <br/>
 

--- a/docs/source/integration/sglang.md
+++ b/docs/source/integration/sglang.md
@@ -23,7 +23,7 @@ P2P sharing without network transfer.
 is included in a release):
 
 ```bash
-pip install "sglang[all] @ git+https://github.com/sgl-project/sglang#subdirectory=python"
+uv pip install "sglang[all] @ git+https://github.com/sgl-project/sglang#subdirectory=python"
 ```
 
 See [SGLang installation docs](https://docs.sglang.ai/start/install.html)
@@ -164,7 +164,7 @@ for details on the write-through flush mechanism.
 |---------|-------|-----|
 | `RuntimeError: Failed to connect MaruHandler` | MaruServer not running | Start `maru-server --port 5555` |
 | No cache hits on Instance 2 | Write-through not flushed | Send two queries to Instance 1 first (hit-count threshold) and wait ~3s |
-| `ImportError: maru_sglang` | Package not installed | Run `pip install -e .` from `maru/` root |
+| `ImportError: maru_sglang` | Package not installed | Run `uv pip install -e .` from `maru/` root |
 | Low TTFT speedup (< 1.5×) | Prompt too short for meaningful prefill savings | Use longer prompts (> 500 tokens) |
 
 > **See also:** [Architecture Overview](../design_doc/architecture_overview.md),

--- a/docs/source/integration/vllm.md
+++ b/docs/source/integration/vllm.md
@@ -5,7 +5,7 @@
 **vLLM v0.14+** — required for `KVConnectorBase_V1` support:
 
 ```bash
-pip install vllm
+uv pip install vllm
 ```
 
 See [vLLM installation docs](https://docs.vllm.ai/en/latest/getting_started/installation.html)

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -4,7 +4,7 @@ Demonstrates Maru's core functionality: zero-copy KV store on CXL shared memory.
 
 ## Prerequisites
 
-- Maru installed (`pip install -e .`)
+- Maru installed (`uv pip install -e .`)
 - Maru Resource Manager running (`systemctl status maru-resourced`)
 - CXL DAX device available (`/dev/dax*`)
 

--- a/examples/lmcache/disagg_prefill/1p1d/README.md
+++ b/examples/lmcache/disagg_prefill/1p1d/README.md
@@ -4,8 +4,8 @@ This example demonstrates how to run LMCache with disaggregated prefill on a sin
 
 ### Prerequisites
 
-- Install [LMCache](https://github.com/LMCache/LMCache). You can simply run `pip install lmcache`.
-- Install [Maru](https://github.com/xcena-dev/maru). Run `pip install -e .` from the maru repo root.
+- Install [LMCache](https://github.com/LMCache/LMCache). You can simply run `uv pip install lmcache`.
+- Install [Maru](https://github.com/xcena-dev/maru). Run `uv pip install -e .` from the maru repo root.
 - At least 2 GPUs
 
 ### Usage

--- a/examples/lmcache/disagg_prefill/1p1d/disagg_example_1p1d.sh
+++ b/examples/lmcache/disagg_prefill/1p1d/disagg_example_1p1d.sh
@@ -42,7 +42,7 @@ ensure_python_library_installed() {
     echo "Checking if $1 is installed..."
     python -c "import $1" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
-        echo "$1 is not installed. Please install it via pip install $1."
+        echo "$1 is not installed. Please install it via uv pip install $1."
         exit 1
     else
         echo "$1 is installed."

--- a/examples/lmcache/disagg_prefill/README.md
+++ b/examples/lmcache/disagg_prefill/README.md
@@ -29,8 +29,8 @@ This is the simplest configuration to get started with disaggregated prefill.
 
 Before running any example, ensure you have:
 
-- [LMCache](https://github.com/LMCache/LMCache) installed: `pip install lmcache`
-- [Maru](https://github.com/xcena-dev/maru) installed: `pip install -e .`
+- [LMCache](https://github.com/LMCache/LMCache) installed: `uv pip install lmcache`
+- [Maru](https://github.com/xcena-dev/maru) installed: `uv pip install -e .`
 - Sufficient GPU resources (see individual example requirements)
 
 ## Quick Start

--- a/examples/lmcache/p2p_sharing/README.md
+++ b/examples/lmcache/p2p_sharing/README.md
@@ -12,7 +12,7 @@ Maru provides CXL shared memory backed storage, eliminating the need for P2P tra
 
 ```bash
 cd ~/maru
-pip install -e .
+uv pip install -e .
 ```
 
 2. At least 2 GPUs available

--- a/examples/lmcache/p2p_sharing/p2p_example.sh
+++ b/examples/lmcache/p2p_sharing/p2p_example.sh
@@ -40,7 +40,7 @@ ensure_python_library_installed() {
     echo "Checking if $1 is installed..."
     python3 -c "import $1" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
-        echo "$1 is not installed. Please install it via pip install $1."
+        echo "$1 is not installed. Please install it via uv pip install $1."
         exit 1
     else
         echo "$1 is installed."

--- a/examples/lmcache/single/single_example.sh
+++ b/examples/lmcache/single/single_example.sh
@@ -18,7 +18,7 @@ ensure_python_library_installed() {
     echo "Checking if $1 is installed..."
     python3 -c "import $1" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
-        echo "$1 is not installed. Please install it via pip install $1."
+        echo "$1 is not installed. Please install it via uv pip install $1."
         exit 1
     else
         echo "$1 is installed."

--- a/examples/sglang/p2p_sharing/README.md
+++ b/examples/sglang/p2p_sharing/README.md
@@ -6,7 +6,7 @@ shared L3 pool, reducing TTFT on repeated prompts.
 
 ## Prerequisites
 
-1. Install Maru: `pip install -e .` (from the `maru/` root)
+1. Install Maru: `uv pip install -e .` (from the `maru/` root)
 2. SGLang with [sgl-project/sglang#20560](https://github.com/sgl-project/sglang/pull/20560)
 3. At least 2 GPUs available
 

--- a/examples/sglang/p2p_sharing/p2p_example.sh
+++ b/examples/sglang/p2p_sharing/p2p_example.sh
@@ -29,7 +29,7 @@ ensure_python_library_installed() {
     echo "Checking if $1 is installed..."
     python3 -c "import $1" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
-        echo "$1 is not installed. Please install it via pip install $1."
+        echo "$1 is not installed. Please install it via uv pip install $1."
         exit 1
     else
         echo "$1 is installed."

--- a/examples/sglang/single/README.md
+++ b/examples/sglang/single/README.md
@@ -4,7 +4,7 @@ Run a single SGLang instance with Maru HiCache L3 backend (CXL shared memory).
 
 ## Prerequisites
 
-1. Install Maru: `pip install -e .` (from the `maru/` root)
+1. Install Maru: `uv pip install -e .` (from the `maru/` root)
 2. SGLang with [sgl-project/sglang#20560](https://github.com/sgl-project/sglang/pull/20560)
 3. At least 1 GPU available
 

--- a/examples/sglang/single/single_example.sh
+++ b/examples/sglang/single/single_example.sh
@@ -18,7 +18,7 @@ ensure_python_library_installed() {
     echo "Checking if $1 is installed..."
     python3 -c "import $1" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
-        echo "$1 is not installed. Please install it via pip install $1."
+        echo "$1 is not installed. Please install it via uv pip install $1."
         exit 1
     else
         echo "$1 is installed."

--- a/examples/vllm/p2p_sharing/README.md
+++ b/examples/vllm/p2p_sharing/README.md
@@ -21,7 +21,7 @@ Instance 1 (GPU 0)                    Instance 2 (GPU 1)
 ## Prerequisites
 
 - 2+ NVIDIA GPUs
-- maru installed: `pip install -e /path/to/maru`
+- maru installed: `uv pip install -e /path/to/maru`
 - vLLM v0.14+ installed
 - maru-server binary available
 - LMCache is optional. When its Python package is installed, the direct

--- a/examples/vllm/single/README.md
+++ b/examples/vllm/single/README.md
@@ -29,7 +29,7 @@ connector's store/load paths would never run.
 ## Prerequisites
 
 - 1+ NVIDIA GPU
-- maru installed: `pip install -e /path/to/maru`
+- maru installed: `uv pip install -e /path/to/maru`
 - vLLM v0.14+ installed
 - maru-server binary available
 - LMCache is optional. When its Python package is installed, the direct

--- a/examples/vllm/single/single_example.sh
+++ b/examples/vllm/single/single_example.sh
@@ -23,7 +23,7 @@ ensure_python_library_installed() {
     echo "Checking if $1 is installed..."
     python3 -c "import $1" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
-        echo "$1 is not installed. Please install it via pip install $1."
+        echo "$1 is not installed. Please install it via uv pip install $1."
         exit 1
     else
         echo "$1 is installed."

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # NOTE: We recommend using a virtual environment before running this script.
-#   python3 -m venv .venv && source .venv/bin/activate
+#   uv venv --python 3.12 .venv && source .venv/bin/activate
+# (or, without uv: python3 -m venv .venv && source .venv/bin/activate)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -56,14 +57,32 @@ check_cmd gcc build-essential
 
 if [ -z "${VIRTUAL_ENV:-}" ]; then
     echo "Warning: No virtual environment detected."
-    echo "We recommend using a venv: python3 -m venv .venv && source .venv/bin/activate"
+    echo "We recommend using a venv: uv venv --python 3.12 .venv && source .venv/bin/activate"
     echo ""
+fi
+
+# --- Select the Python installer -------------------------------------------
+
+# uv is preferred (much faster resolve/build); pip remains a working fallback.
+if command -v uv &>/dev/null; then
+    INSTALL_CMD=(uv pip install)
+    # uv refuses to guess a target when no virtual environment is active,
+    # so point it at the python3 on PATH to match pip's behaviour.
+    if [ -z "${VIRTUAL_ENV:-}" ]; then
+        INSTALL_CMD+=(--python "$(command -v python3)")
+    fi
+else
+    echo "Note: uv not found, falling back to pip."
+    echo "      Installing uv makes this step significantly faster:"
+    echo "        curl -LsSf https://astral.sh/uv/install.sh | sh"
+    echo ""
+    INSTALL_CMD=(pip install)
 fi
 
 # --- Install Python package ------------------------------------------------
 
 echo "Installing Maru Python package ..."
-pip install -e "${SCRIPT_DIR}"
+"${INSTALL_CMD[@]}" -e "${SCRIPT_DIR}"
 
 # --- Build and install resource manager ------------------------------------
 

--- a/maru_common/resource_manager_installer.py
+++ b/maru_common/resource_manager_installer.py
@@ -2,7 +2,7 @@
 # Copyright 2026 XCENA Inc.
 """Console script entry point for installing the Maru Resource Manager.
 
-Wraps the cmake build + install workflow so that after `pip install -e .`,
+Wraps the cmake build + install workflow so that after `uv pip install -e .`,
 a single `sudo $(which install-maru-resource-manager)` builds and installs
 the Maru Resource Manager.
 """
@@ -107,7 +107,7 @@ def _do_install(args: argparse.Namespace) -> int:
         fprintf(
             sys.stderr,
             "Error: maru_resource_manager source directory not found.\n"
-            "This command requires an editable install: pip install -e .\n",
+            "This command requires an editable install: uv pip install -e .\n",
         )
         return 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "mypy>=1.0.0",
     "ruff>=0.1.0",
+    "pre-commit>=3.0.0",
 ]
 docs = [
     "sphinx>=7.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,0 @@
-# Development dependencies
--r requirements.txt
-pytest>=7.0.0
-pytest-cov>=4.0.0
-mypy>=1.0.0
-ruff>=0.1.0
-pre-commit>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-# Core dependencies
-pyzmq>=25.0.0
-msgpack>=1.0.0
-dacite>=1.8.0
-numpy>=1.24.0


### PR DESCRIPTION
## 🤔 Background & Motivation (Why)

- #50 asks for uv adoption to make testing and running easier, citing [LMCache's CONTRIBUTING guide](https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md). Every install path in the repo (`install.sh`, CI, docs, examples) was pip-based.
- A second problem surfaced while doing it: dependencies were declared **twice** and had drifted. CI installed from `requirements*.txt` while `install.sh` installed from `pyproject.toml`, and only the former carried `numpy>=1.24.0`.

## 🏗️ Design Changes

- **Dependency source**: `requirements.txt` / `requirements-dev.txt` removed. `pyproject.toml` is now the single source. CI installs the `dev` extra, which gains `pre-commit>=3.0.0` so it still covers what `requirements-dev.txt` did.
- **Build backend: unchanged** (setuptools via PEP 621). uv drives the existing backend, so `maru_shm._cxl_flush` builds exactly as it did under pip. No packaging changes.
- **uv is recommended, not required**: `install.sh` prefers uv when on PATH and falls back to pip, and the docs give the pip equivalent alongside every uv command.
- **ruff is now pinned to one version.** CI took whatever `uvx ruff` resolved to while `.pre-commit-config.yaml` pinned `v0.11.7`; both are now `v0.16.5`, so a new ruff release cannot break CI without a code change and local hooks match CI.
- **Deliberately not adopted: `uv.lock` / `uv sync` project mode.** maru installs into an environment it does not own — torch, vLLM, SGLang and Dynamo are not declared dependencies — and `uv sync` prunes anything absent from the lock, which would break that environment. LMCache has no `uv.lock` either; its CONTRIBUTING recommends exactly the `uv venv` + `uv pip install -e .` flow used here.

## 📝 Implementation Details

- `install.sh`: builds an `INSTALL_CMD` array. With uv and no active virtualenv it appends `--python "$(command -v python3)"` so the install target matches what pip would have picked (conda environments included).
- CI (3 workflows): `astral-sh/setup-uv@v6` with `enable-cache: true`. `test.yml` and `docs-sphinx.yml` use `uv pip install --system -e ".[dev|docs]"`; `lint.yml` uses `uvx ruff@0.16.5` and no longer needs `actions/setup-python`.
- `.pre-commit-config.yaml`: `rev` bumped to `v0.16.5` to match CI, and the hook id moved from the deprecated `ruff` alias to `ruff-check`.
- Docs/examples (20 files): `pip install` → `uv pip install`; `python3 -m venv` → `uv venv --python 3.12`, pinned so the interpreter stays reproducible next to a vLLM/SGLang install. New `installation.md` §1.3 **Development Install** documents the dev extra, its pip equivalent, `pre-commit install`, the unit-test command, and `pre-commit run --all-files` for reproducing the lint job.

### Note on the ruff pin

Pinning to the *older* `v0.11.7` — the version `.pre-commit-config.yaml` already carried — would have broken CI. `ruff 0.11.7` reports `UP038` twice in `maru_vllm/connector.py`, on code that is already on `main` and untouched by this PR, and that rule has since been **removed from ruff** (PEP 604 syntax in `isinstance` is not recommended and is slower). Unifying upward on `v0.16.5` reaches the same goal — one version, CI and pre-commit in agreement — without touching runtime code.

### Note on numpy

No packaged module imports numpy directly. The `.numpy()` call sites in `maru_vllm/connector.py` and `maru_sglang/maru_storage.py` do require it at runtime, but they only execute on vLLM/SGLang paths, and both frameworks pull numpy in transitively; `examples/lmcache/disagg_prefill/disagg_proxy_server.py` imports it directly and is likewise vLLM-only. The tests touching `torch.Tensor.numpy()` sit behind `pytest.importorskip("torch")`, so CI never needed the pin.

## ✅ Tests

- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] No tests needed (reason:                )

Evidence, in clean Python 3.12 venvs:

| Check | Result |
|---|---|
| `uv pip install -e ".[dev]"` from clean venv | builds C extension, 0.9s |
| `pip install -e ".[dev]"` (documented fallback) | builds C extension |
| Unit tests, both install paths | **720 passed, 4 skipped** |
| `uvx ruff@0.16.5 check .` / `format --check .` | clean / 116 files formatted |
| `pre-commit run --all-files` at the new pin | ruff check Passed, ruff format Passed |
| `install.sh --no-rm`, uv path with venv active | installs, C extension built |
| `install.sh --no-rm`, no virtualenv | command **constructed** correctly as `uv pip install --python /usr/bin/python3`; the install itself is then blocked by PEP 668 on Ubuntu's system Python, exactly as the previous pip path was |

**Not covered by PR CI:** `docs-sphinx.yml` triggers only on push to `main` and `workflow_dispatch`, so its `uv pip install --system -e ".[docs]"` first runs on merge. Running it manually from this branch would deploy branch docs to Pages, so the first post-merge deploy is worth a glance.

## 🔗 Related Issues (optional)

- Refs #50

## 📦 Release Note (for auto-generation / write in English)

### NEW
- Docs: "Development Install" section covering the `dev` extra, its pip equivalent, `pre-commit install`, unit tests, and lint commands.

### CHANGED
- Install and CI use uv where available; `install.sh` falls back to pip when uv is absent.
- Dependencies are declared only in `pyproject.toml`. `requirements.txt` and `requirements-dev.txt` are removed — use `uv pip install -e ".[dev]"` (or `pip install -e ".[dev]"`) for a development environment.
- ruff pinned to `v0.16.5` in both CI and pre-commit; pre-commit hook id updated to `ruff-check`.

### FIXED
- Removed the stale `numpy` pin that existed only in `requirements.txt`.
- CI lint no longer floats to the newest ruff release, so a new release cannot fail the build with no code change.

### IMPORTANT NOTES
- Anyone installing via `pip install -r requirements-dev.txt` must switch to `uv pip install -e ".[dev]"` (or `pip install -e ".[dev]"`).
- Run `pre-commit install` after updating; the hook now uses `ruff-check` at `v0.16.5`.
