### PR TITLE
fix: discover DEV_DAX devices whose sysfs path has no region component

### DIFF
--- a/maru_resource_manager/CMakeLists.txt
+++ b/maru_resource_manager/CMakeLists.txt
@@ -69,6 +69,7 @@ if(MARU_BUILD_TESTS)
     add_executable(maru_rm_tests
         tests/test_device_header.cpp
         tests/test_pool_manager_uuid.cpp
+        tests/test_dax_region_index.cpp
         ${RM_LIB_SOURCES}
     )
 

--- a/maru_resource_manager/src/pool_manager.cpp
+++ b/maru_resource_manager/src/pool_manager.cpp
@@ -272,9 +272,46 @@ static void deleteFsDaxFile(const std::string &mountPoint, uint64_t regionId)
     ::unlink(filename.c_str());
 }
 
+bool parseRegionIndexFromDaxName(const std::string &devName, uint32_t &outIndex)
+{
+    // The kernel names every dev_dax "dax<dax_region id>.<dev_dax id>", whatever
+    // the provider is (pmem, CXL region, or hmem), so the device name carries the
+    // region index directly. Unlike the sysfs link target it does not depend on
+    // where the dax_region sits in the device hierarchy.
+    if (devName.compare(0, 3, "dax") != 0)
+    {
+        return false;
+    }
+    const char *p = devName.c_str() + 3;
+    if (!std::isdigit(static_cast<unsigned char>(*p)))
+    {
+        return false;
+    }
+    char *end = nullptr;
+    unsigned long v = std::strtoul(p, &end, 10);
+    if (end == p || *end != '.' ||
+        !std::isdigit(static_cast<unsigned char>(end[1])))
+    {
+        return false;
+    }
+    outIndex = static_cast<uint32_t>(v);
+    return true;
+}
+
 static bool getRegionIndexForDax(const std::string &devName,
                                  uint32_t &outIndex)
 {
+    // Prefer the device name: parseRegionIndexFromTarget() takes the first
+    // "region<N>" anywhere in the link target, which picks up an unrelated
+    // ancestor when one happens to be named that way, and finds nothing at all
+    // for an hmem-backed device (".../devices/platform/hmem.0/dax0.0" has no
+    // region component). The link target stays as a fallback for any layout
+    // whose device name does not parse.
+    if (parseRegionIndexFromDaxName(devName, outIndex))
+    {
+        return true;
+    }
+
     std::string sysfsPath = std::string(kSysBusDaxDevices) + "/" + devName;
     char buf[PATH_MAX];
     ssize_t n = ::readlink(sysfsPath.c_str(), buf, sizeof(buf) - 1);
@@ -349,6 +386,14 @@ int PoolManager::scanDevices(std::vector<DeviceInfo> &outDevices)
             uint32_t regionId = 0;
             if (!getRegionIndexForDax(name, regionId))
             {
+                // Skipping silently here is what made an undiscoverable device
+                // look like an absent one: the daemon only reports "no CXL/DAX
+                // devices found" and never says which device it passed over.
+                logf(LogLevel::Warn,
+                     "scanDevices: cannot determine dax_region index for /dev/%s "
+                     "(unexpected device name and no region in its sysfs link) — "
+                     "skipping, its capacity will not be available",
+                     name);
                 continue;
             }
             std::string devPath = std::string(kDevPrefix) + name;

--- a/maru_resource_manager/src/pool_manager.h
+++ b/maru_resource_manager/src/pool_manager.h
@@ -49,6 +49,14 @@ struct PoolState
 class MetadataStore;
 class WalStore;
 
+/// Extract the dax_region index from a dev_dax device name ("dax3.7" -> 3).
+///
+/// The kernel names every dev_dax "dax<dax_region id>.<dev_dax id>", so this is
+/// authoritative for every provider (pmem, CXL region, hmem) and, unlike parsing
+/// the sysfs link target, does not depend on the device hierarchy layout.
+/// Exposed for testing.
+bool parseRegionIndexFromDaxName(const std::string &devName, uint32_t &outIndex);
+
 class PoolManager
 {
 public:

--- a/maru_resource_manager/tests/test_dax_region_index.cpp
+++ b/maru_resource_manager/tests/test_dax_region_index.cpp
@@ -1,0 +1,55 @@
+// Copyright 2026 XCENA Inc.
+// Unit tests for dax_region index derivation from a dev_dax device name.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+#include "pool_manager.h"
+
+using namespace maru;
+
+namespace {
+
+uint32_t indexOf(const std::string &devName) {
+    uint32_t index = 0xFFFFFFFFu;
+    EXPECT_TRUE(parseRegionIndexFromDaxName(devName, index)) << devName;
+    return index;
+}
+
+bool rejects(const std::string &devName) {
+    uint32_t index = 0;
+    return !parseRegionIndexFromDaxName(devName, index);
+}
+
+}  // namespace
+
+TEST(DaxRegionIndexTest, ParsesRegionIndexFromDeviceName) {
+    EXPECT_EQ(indexOf("dax0.0"), 0u);
+    EXPECT_EQ(indexOf("dax0.1"), 0u);
+    EXPECT_EQ(indexOf("dax3.7"), 3u);
+    EXPECT_EQ(indexOf("dax12.0"), 12u);
+}
+
+TEST(DaxRegionIndexTest, RejectsMalformedNames) {
+    EXPECT_TRUE(rejects("dax"));
+    EXPECT_TRUE(rejects("dax0"));         // no dev_dax id
+    EXPECT_TRUE(rejects("dax0."));        // trailing dot
+    EXPECT_TRUE(rejects("dax.0"));        // no region id
+    EXPECT_TRUE(rejects("daxfoo"));
+    EXPECT_TRUE(rejects("dax_region"));   // attribute group dir, not a device
+    EXPECT_TRUE(rejects("pmem0"));
+    EXPECT_TRUE(rejects(""));
+}
+
+// Regression: an hmem-backed device resolves to
+// "../../../devices/platform/hmem.0/dax0.0", which carries no "region<N>"
+// component, so deriving the index from the sysfs link target cannot work and
+// the device used to be skipped, leaving the daemon with no pools.
+TEST(DaxRegionIndexTest, ResolvesHmemDeviceWhoseLinkTargetHasNoRegion) {
+    const std::string hmemTarget = "../../../devices/platform/hmem.0/dax0.0";
+    ASSERT_EQ(hmemTarget.find("region"), std::string::npos);
+
+    EXPECT_EQ(indexOf("dax0.0"), 0u);
+}


### PR DESCRIPTION
## 🤔 Background & Motivation (Why)

The resource manager finds no pool on a machine whose DAX device sits under a platform hmem device, even though the device is present and healthy (`daxctl` reports `mode: devdax`, `/dev/dax0.0` exists, the UUID header is written):

```
$ maru-resource-manager --state-dir $(mktemp -d)
no CXL/DAX devices found — starting with empty pool
ready — listening on 0.0.0.0:9850
pools empty, rescanning for CXL/DAX devices...      (every 10s, forever)
```

With no pool there is nothing to allocate from, so `maru-server` and `MaruHandler` cannot do anything either — Maru is unusable on such a machine, single node included.

`scanDevices()` derived the dax_region index by searching the sysfs symlink target for `region<N>`. That works for pmem (`.../ndbus0/region0/dax_region0/dax0.0`) and for a CXL region, but an hmem-backed device has no region component in its path:

```
$ readlink /sys/bus/dax/devices/dax0.0
../../../devices/platform/hmem.0/dax0.0
```

so the lookup failed and the device was skipped **with no log line** — which is why the only visible symptom was "no devices found".

## 🏗️ Design Changes

- The dax_region index now comes from the device name, with the old link-target parse kept as a fallback. This removes a path dependency rather than adding one: the old code needed the sysfs hierarchy to spell `region<N>`, and that hierarchy differs per provider and per platform. The name does not — `alloc_dax_region` and `devm_create_dev_dax` are built into the kernel core rather than into any module, and `dax_pmem`, `dax_cxl` and `dax_hmem` all call into them, so `dax<dax_region id>.<dev_dax id>` is produced by one shared code path for every provider. Keeping the old parse as a fallback also means the set of discovered devices is a superset of what it was before, so a working setup cannot regress.
- How the device path itself is found is untouched — it never went through the symlink.
- Devices skipped during discovery are now logged with the reason.
- New internal function `parseRegionIndexFromDaxName()`, declared in `pool_manager.h` so tests can link it.
- No change to pool id numbering, the on-disk metadata format, the WAL format, or the wire protocol.

## 📝 Implementation Details

**Only the region-id derivation changes.** How the device path is found is untouched — it never went through the symlink:

| | Before | After |
| --- | --- | --- |
| device path | `/dev/` + entry name from `readdir("/sys/bus/dax/devices")` | *unchanged* |
| region id | first `region<N>` found anywhere in the sysfs link target | first number in the device name; link target only as fallback |

```
Before:  getRegionIndexForDax("dax0.0")
           readlink("/sys/bus/dax/devices/dax0.0") -> ".../platform/hmem.0/dax0.0"
             target.find("region") -> npos  ->  skipped, silently

After:   getRegionIndexForDax("dax0.0")
           parseRegionIndexFromDaxName("dax0.0") -> 0      <- readlink not reached
           (link-target parse runs only if the name does not parse)
```

### Pool ids are unchanged

Worth a reviewer's eye, since `poolId` is a persistence key — it names `pool_<id>.meta` (`metadata.cpp:33`), is rejected on mismatch when loading (`metadata.cpp:54`), and is what WAL replay resolves a pool by (`wal.cpp:125-127`). A renumbering would orphan existing state.

It does not happen here. Wherever discovery already worked, both sources yield the same number: `dax_region->id` equals the `nd_region` id for pmem and the CXL region id for CXL, and that is precisely the `region<N>` in the path. Where discovery failed there was no pool and no metadata to be compatible with.

## ✅ Tests

- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] No tests needed (reason:                )

**Unit** — 3 new gtest cases in `tests/test_dax_region_index.cpp`; `ctest` 19/19, clean under `-Wall -Wextra -Wpedantic`.

| Case | Covers |
| --- | --- |
| `ParsesRegionIndexFromDeviceName` | `dax0.0`, `dax0.1`, `dax3.7`, `dax12.0` |
| `RejectsMalformedNames` | `dax`, `dax0`, `dax0.`, `dax.0`, `daxfoo`, `dax_region`, `pmem0`, `""` |
| `ResolvesHmemDeviceWhoseLinkTargetHasNoRegion` | asserts the hmem link target has no `region` component, and that the name still resolves — the regression |

**Manual**, on an hmem-backed devdax device: the rescan loop is gone and the pool registers at startup. `STATS_REQ` reports the pool, and `ALLOC_REQ` → mmap → write → `FREE_REQ` completes. The full stack (resource manager + `maru-server` + two `MaruHandler` clients storing and retrieving over several rounds) runs green, with the two clients receiving disjoint ranges.

Not covered: no pmem or CXL-region machine was available, so the claim that those topologies are unaffected rests on the two arguments above rather than on a run. On such a machine it can be checked in a minute — for every device the first number of the name should equal `dax_region/id`, and `pool_<id>.meta` should keep its existing filename.

## 🔗 Related Issues (optional)

-

## 📦 Release Note (for auto-generation / write in English)
### NEW
-
### CHANGED
- Resource Manager: skipped DAX devices are now logged with the reason instead of being passed over silently.
### FIXED
- Resource Manager: DEV_DAX devices whose sysfs path carries no `region<N>` component (e.g. a `dax_region` on a platform hmem device) were skipped during discovery, leaving the daemon with no pools and no way to allocate.
### IMPORTANT NOTES
-
